### PR TITLE
Remove the `type` field as is deprecated in the `ir.ui.view` model.

### DIFF
--- a/connector/queue/model_view.xml
+++ b/connector/queue/model_view.xml
@@ -26,7 +26,6 @@
         <record id="view_queue_worker_tree" model="ir.ui.view">
             <field name="name">queue.worker.tree</field>
             <field name="model">queue.worker</field>
-            <field name="type">tree</field>
             <field name="arch" type="xml">
                 <tree string="Worker" create="false"
                         delete="false" edit="false" version="7.0">


### PR DESCRIPTION
Removes the warning

```
2014-09-03 14:02:17,563 29154 WARNING oif openerp.addons.base.ir.ir_ui_view: Setting the `type` field is deprecated in the `ir.ui.view` model.
```
