### PR TITLE
Fixes #18. The init of `Environment` object is broken 

### DIFF
--- a/connector/connector.py
+++ b/connector/connector.py
@@ -236,7 +236,8 @@ class Environment(object):
         :type model_name: str
         """
         self.backend_record = backend_record
-        self.backend = backend_record.get_backend()
+        backend = backend_record.get_backend()
+        self.backend = backend[0]
         self.session = session
         self.model_name = model_name
         self.model = self.session.pool.get(model_name)

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -400,7 +400,7 @@ class test_mapper_binding(common.TransactionCase):
         self.backend = mock.Mock(wraps=Backend('x', version='y'),
                                  name='backend')
         backend_record = mock.Mock()
-        backend_record.get_backend.return_value = self.backend
+        backend_record.get_backend.return_value = [self.backend]
         self.env = Environment(backend_record, self.session, 'res.partner')
         self.country_binder = mock.Mock(name='country_binder')
         self.country_binder.return_value = self.country_binder
@@ -466,7 +466,7 @@ class test_mapper_binding(common.TransactionCase):
             children = [('lines', 'line_ids', 'res.currency.rate')]
 
         backend_record = mock.Mock()
-        backend_record.get_backend.side_effect = lambda *a: backend
+        backend_record.get_backend.side_effect = lambda *a: [backend]
         env = Environment(backend_record, self.session, 'res.currency')
 
         record = {'name': 'SO1',
@@ -528,7 +528,7 @@ class test_mapper_binding(common.TransactionCase):
             children = [('lines', 'line_ids', 'res.currency.rate')]
 
         backend_record = mock.Mock()
-        backend_record.get_backend.side_effect = lambda *a: backend
+        backend_record.get_backend.side_effect = lambda *a: [backend]
         env = Environment(backend_record, self.session, 'res.currency')
 
         record = {'name': 'SO1',

--- a/connector/tests/test_related_action.py
+++ b/connector/tests/test_related_action.py
@@ -101,7 +101,7 @@ class test_related_action(unittest2.TestCase):
         backend = mock.Mock(name='backend')
         browse_record = mock.Mock(name='browse_record')
         backend.get_class.return_value = TestBinder
-        backend_record.get_backend.return_value = backend
+        backend_record.get_backend.return_value = [backend]
         browse_record.exists.return_value = True
         browse_record.backend_id = backend_record
         session.browse.return_value = browse_record


### PR DESCRIPTION
as backend model are now new Odoo API model.

The result  of function `get_backend` is mapped to a list so we have a list of `backend.Backend` object (not model)
It seems it is possible to have correct result using decorator and downgrade keywork but I do not like it.
