### PR TITLE
replace deprecated pooler.get_pool() by registry()

### DIFF
--- a/connector/openerp-connector-worker
+++ b/connector/openerp-connector-worker
@@ -65,7 +65,7 @@ class WorkerConnector(workers.Worker):
         else:
             if cr.fetchone():
                 RegistryManager.check_registry_signaling(db_name)
-                registry = openerp.pooler.get_pool(db_name)
+                registry = openerp.registry(db_name)
                 if registry:
                     queue_worker = registry['queue.worker']
                     queue_worker.assign_then_enqueue(cr,

--- a/connector/session.py
+++ b/connector/session.py
@@ -127,7 +127,7 @@ class ConnectorSession(object):
     @property
     def pool(self):
         if self._pool is None:
-            self._pool = openerp.pooler.get_pool(self.cr.dbname)
+            self._pool = openerp.registry(self.cr.dbname)
         return self._pool
 
     @contextmanager


### PR DESCRIPTION
Fixes https://github.com/OCA/connector/issues/20
