### PR TITLE
name_get implementations expect a list of ids

### DIFF
--- a/connector/checkpoint/checkpoint.py
+++ b/connector/checkpoint/checkpoint.py
@@ -58,7 +58,7 @@ class connector_checkpoint(orm.Model):
         res = {}
         for check in self.browse(cr, uid, ids, context=context):
             model_obj = self.pool.get(check.model_id.model)
-            res[check.id] = model_obj.name_get(cr, uid, check.record_id,
+            res[check.id] = model_obj.name_get(cr, uid, [check.record_id],
                                                context=context)[0][1]
         return res
 


### PR DESCRIPTION
the original orm.py name_get function checks the type of 'ids' but not so most of the addons implementations
