### PR TITLE
[FIX][connector] switch unlink of producer into the new api to avoid old...

### DIFF
--- a/connector/producer.py
+++ b/connector/producer.py
@@ -63,7 +63,7 @@ def write(self, vals):
         session = ConnectorSession(self.env.cr, self.env.uid,
                                    context=self.env.context)
         if on_record_write.has_consumer_for(session, self._name):
-            for record_id in self._ids:
+            for record_id in self.ids:
                 on_record_write.fire(session, self._name,
                                      record_id, vals)
     return result
@@ -79,7 +79,7 @@ def unlink(self):
         session = ConnectorSession(self.env.cr, self.env.uid,
                                    context=self.env.context)
         if on_record_unlink.has_consumer_for(session, self._name):
-            for record_id in self._ids:
+            for record_id in self.ids:
                 on_record_unlink.fire(session, self._name, record_id)
     return unlink_original(self)
 orm.BaseModel.unlink = unlink

--- a/connector/producer.py
+++ b/connector/producer.py
@@ -73,13 +73,13 @@ orm.BaseModel.write = write
 unlink_original = orm.BaseModel.unlink
 
 
-def unlink(self, cr, uid, ids, context=None):
+@openerp.api.multi
+def unlink(self):
     if self.pool.get('connector.installed') is not None:
-        if not hasattr(ids, '__iter__'):
-            ids = [ids]
-        session = ConnectorSession(cr, uid, context=context)
+        session = ConnectorSession(self.env.cr, self.env.uid,
+                                   context=self.env.context)
         if on_record_unlink.has_consumer_for(session, self._name):
-            for record_id in ids:
+            for record_id in self._ids:
                 on_record_unlink.fire(session, self._name, record_id)
-    return unlink_original(self, cr, uid, ids, context=context)
+    return unlink_original(self)
 orm.BaseModel.unlink = unlink


### PR DESCRIPTION
.../new odoo confusion
- Create a Database
- Install "Products & Pricelists"  & "Purchase" & "Sales Management"
- Settings/Configuration/Purchases --> Manage different units of measure for products
- Settings/Configuration/Purchases --> Manage pricelist per supplier
- Invoicing/Create customer "customer"
- Édit "customer" and change its "Purchase Pricelist" (create a second one before)
- Install connector module
- Edit the created "customer" and change its "Purchase Pricelist" with the default one (it must be the real default purchase pricelist because it will make an unlink)
- Save and see "TypeError: unlink() takes at least 4 arguments (1 given)"
## Into 

```
`@api.model
 def set_multi(self, name, model, values):`
```

of `ir.property`
## Behavior without connector:

the `prop.unlink()` is well redirected to 
    `BaseModel.unlink(cr, uid, ids, context)` passing by the wrapper/new_api

**--> works pretty well**

---
## Behavior with connector:

the `prop.unlink()` is NOT well redirected:

```
`producer.unlink(cr, uid, ids, context)` passing by the wrapper/OLD_API
```

**--> takes at least 4 arguments (1 given)**
## Supposion:

I personally do not think this is a `connector` bug because it mostly appears as a 
`old/new api` problem (seems that `unlink` is called as new `api` from `ir.property`
but not defined as such into `BaseModel`).

**BUT** it can be resolved by switching the `producer.unlink` into new `api`.

If you have some other solution and/or any ideas

(Note that test will fail:  maybe rebase after merging this https://github.com/OCA/connector/pull/31)

-jne
