### PR TITLE
backend_record.get_backend *must* return a backend, not a list of backends

### DIFF
--- a/connector/backend_model.py
+++ b/connector/backend_model.py
@@ -39,7 +39,7 @@ class connector_backend(orm.AbstractModel):
         'version': fields.selection((), 'Version', required=True),
     }
 
-    def get_backend(self, cr, uid, id, context=None):
+    def get_backend(self, cr, uid, ids, context=None):
         """ For a record of backend, returns the appropriate instance
         of :py:class:`~connector.backend.Backend`.
         """

--- a/connector/connector.py
+++ b/connector/connector.py
@@ -237,7 +237,7 @@ class Environment(object):
         """
         self.backend_record = backend_record
         backend = backend_record.get_backend()
-        self.backend = backend[0]
+        self.backend = backend
         self.session = session
         self.model_name = model_name
         self.model = self.session.pool.get(model_name)

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -400,7 +400,7 @@ class test_mapper_binding(common.TransactionCase):
         self.backend = mock.Mock(wraps=Backend('x', version='y'),
                                  name='backend')
         backend_record = mock.Mock()
-        backend_record.get_backend.return_value = [self.backend]
+        backend_record.get_backend.return_value = self.backend
         self.connector_env = Environment(
             backend_record, self.session, 'res.partner')
         self.country_binder = mock.Mock(name='country_binder')
@@ -467,7 +467,7 @@ class test_mapper_binding(common.TransactionCase):
             children = [('lines', 'line_ids', 'res.currency.rate')]
 
         backend_record = mock.Mock()
-        backend_record.get_backend.side_effect = lambda *a: [backend]
+        backend_record.get_backend.side_effect = lambda *a: backend
         env = Environment(backend_record, self.session, 'res.currency')
 
         record = {'name': 'SO1',
@@ -529,7 +529,7 @@ class test_mapper_binding(common.TransactionCase):
             children = [('lines', 'line_ids', 'res.currency.rate')]
 
         backend_record = mock.Mock()
-        backend_record.get_backend.side_effect = lambda *a: [backend]
+        backend_record.get_backend.side_effect = lambda *a: backend
         env = Environment(backend_record, self.session, 'res.currency')
 
         record = {'name': 'SO1',

--- a/connector/tests/test_related_action.py
+++ b/connector/tests/test_related_action.py
@@ -101,7 +101,7 @@ class test_related_action(unittest2.TestCase):
         backend = mock.Mock(name='backend')
         browse_record = mock.Mock(name='browse_record')
         backend.get_class.return_value = TestBinder
-        backend_record.get_backend.return_value = [backend]
+        backend_record.get_backend.return_value = backend
         browse_record.exists.return_value = True
         browse_record.backend_id = backend_record
         session.browse.return_value = browse_record


### PR DESCRIPTION
The previous fix took the first item of the list on the result of the method,
but it adds the burden on all the callers to do the same thing.

Instead, changing the 'id' to 'ids' in the method's arguments makes the API use
the correct wrapper and returns one backend instead of a list.

Reverts f5bf250 and 6bf7299
