### PR TITLE
[FIX] connector worker: jobs must be set done in same transaction as job execution

### DIFF
--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -122,11 +122,9 @@ class Worker(threading.Thread):
             _logger.debug('%s started', job)
             with session_hdl.session() as session:
                 job.perform(session)
-            _logger.debug('%s done', job)
-
-            with session_hdl.session() as session:
                 job.set_done()
                 self.job_storage_class(session).store(job)
+            _logger.debug('%s done', job)
 
         except NothingToDoJob as err:
             if unicode(err):


### PR DESCRIPTION
Otherwise a crash at the wrong moment could leave an incoherent job state.
