### PR TITLE
[8.0] job runner

### DIFF
--- a/connector/AUTHORS
+++ b/connector/AUTHORS
@@ -9,3 +9,4 @@
 * Leonardo Pistone at Camptocamp
 * David Béal at Akretion (tiny change)
 * Christophe Combelles at Anybox (french translation)
+* Stéphane Bidoul at Acsone (job runner)

--- a/connector/__init__.py
+++ b/connector/__init__.py
@@ -5,3 +5,4 @@ from . import queue
 from . import connector
 from . import producer
 from . import checkpoint
+from . import controllers

--- a/connector/__init__.py
+++ b/connector/__init__.py
@@ -6,3 +6,4 @@ from . import connector
 from . import producer
 from . import checkpoint
 from . import controllers
+from . import jobrunner

--- a/connector/__openerp__.py
+++ b/connector/__openerp__.py
@@ -28,6 +28,9 @@
  'category': 'Generic Modules',
  'depends': ['mail'
              ],
+ 'external_dependencies': {'python': ['requests'
+                                      ],
+                           },
  'data': ['security/connector_security.xml',
           'security/ir.model.access.csv',
           'queue/model_view.xml',

--- a/connector/channels.py
+++ b/connector/channels.py
@@ -301,6 +301,10 @@ class Channel:
     none in use. This means that whenever a new job comes in channel B,
     there will be available room for it to run in the root channel.
 
+    Note that from the point of view of a channel, 'running' means enqueued
+    in the downstream channel. Only jobs marked running in the root channel
+    are actually sent to Odoo for execution.
+
     Should a downstream channel have less capacity than its upstream channels,
     jobs going downstream will be enqueued in the downstream channel,
     and compete normally according to their properties (priority, etc).

--- a/connector/channels.py
+++ b/connector/channels.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of connector, an Odoo module.
+#
+#     Author: Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     connector is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     connector is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with connector.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import datetime
+from heapq import heappush, heappop
+import logging
+from weakref import WeakValueDictionary
+
+_logger = logging.getLogger(__name__)
+
+
+STATE_PENDING = 'pending'
+STATE_ENQUEUED = 'enqueued'
+STATE_STARTED = 'started'
+STATE_FAILED = 'failed'
+STATE_DONE = 'done'
+
+STATES_NOT_DONE = (STATE_PENDING, STATE_ENQUEUED, STATE_STARTED, STATE_FAILED)
+
+
+class PriorityQueue:
+    """A priority queue that supports removing arbitrary objects.
+
+    Adding an object already in the queue is a no op.
+    Popping an empty queue returns None.
+
+    >>> q = PriorityQueue()
+    >>> q.add(2)
+    >>> q.add(3)
+    >>> q.add(3)
+    >>> q.add(1)
+    >>> q[0]
+    1
+    >>> len(q)
+    3
+    >>> q.pop()
+    1
+    >>> q.remove(2)
+    >>> len(q)
+    1
+    >>> q[0]
+    3
+    >>> q.pop()
+    3
+    >>> q.pop()
+    >>> q.add(2)
+    >>> q.remove(2)
+    >>> q.add(2)
+    >>> q.pop()
+    2
+    """
+
+    def __init__(self):
+        self._heap = []
+        self._known = set()    # all objects in the heap (including removed)
+        self._removed = set()  # all objects that have been removed
+
+    def __len__(self):
+        return len(self._known) - len(self._removed)
+
+    def __getitem__(self, i):
+        if i != 0:
+            raise IndexError()
+        while True:
+            if not self._heap:
+                raise IndexError()
+            o = self._heap[0]
+            if o in self._removed:
+                o2 = heappop(self._heap)
+                assert o2 == o
+                self._removed.remove(o)
+                self._known.remove(o)
+            else:
+                return o
+
+    def __contains__(self, o):
+        return o in self._known and o not in self._removed
+
+    def add(self, o):
+        if o is None:
+            raise ValueError()
+        if o in self._removed:
+            self._removed.remove(o)
+        if o in self._known:
+            return
+        self._known.add(o)
+        heappush(self._heap, o)
+
+    def remove(self, o):
+        if o is None:
+            raise ValueError()
+        if o not in self._known:
+            return
+        if o not in self._removed:
+            self._removed.add(o)
+
+    def pop(self):
+        while True:
+            try:
+                o = heappop(self._heap)
+            except IndexError:
+                # queue is empty
+                return None
+            self._known.remove(o)
+            if o in self._removed:
+                self._removed.remove(o)
+            else:
+                return o
+
+
+class SafeSet(set):
+    """A set that does not raise KeyError when removing non-existent items.
+
+    >>> s = SafeSet()
+    >>> s.remove(1)
+    >>> len(s)
+    0
+    >>> s.remove(1)
+    """
+    def remove(self, o):
+        try:
+            super(SafeSet, self).remove(o)
+        except KeyError:
+            pass
+
+
+class ChannelJob:
+    """A channel job is attached to a channel and holds the properties of a
+    job that are necessary to prioritise them.
+
+    Channel jobs are comparable according to the following rules:
+        * jobs with an eta come before all other jobs
+        * then jobs with a smaller eta come first
+        * then jobs with smaller priority come first
+        * then jobs with a smaller creation time come first
+        * then jobs with a samller sequence come first
+
+    Here are some examples.
+
+    j1 comes before j2 before it has a smaller date_created
+    >>> j1 = ChannelJob(None, 1, seq=0, date_created=1, priority=9, eta=None)
+    >>> j1
+    <ChannelJob 1>
+    >>> j2 = ChannelJob(None, 2, seq=0, date_created=2, priority=9, eta=None)
+    >>> j1 < j2
+    True
+
+    j3 comes first because it has lower priority,
+    despite having a creation date after j1 and j2
+    >>> j3 = ChannelJob(None, 3, seq=0, date_created=3, priority=2, eta=None)
+    >>> j3 < j1
+    True
+
+    j4 and j5 comes even before j3, because they have an eta
+    >>> j4 = ChannelJob(None, 4, seq=0, date_created=4, priority=9, eta=9)
+    >>> j5 = ChannelJob(None, 5, seq=0, date_created=5, priority=9, eta=9)
+    >>> j4 < j5 < j3
+    True
+
+    j6 has same date_created and priority as j5 but a smaller eta
+    >>> j6 = ChannelJob(None, 6, seq=0, date_created=5, priority=9, eta=2)
+    >>> j6 < j4 < j5
+    True
+
+    Here is the complete suite:
+    >>> j6 < j4 < j5 < j3 < j1 < j2
+    True
+
+    j0 has the same properties as j1 but they are not considered
+    equal as they are different instances
+    >>> j0 = ChannelJob(None, 1, seq=0, date_created=1, priority=9, eta=None)
+    >>> j0 == j1
+    False
+    >>> j0 == j0
+    True
+    """
+
+    def __init__(self, channel, uuid, seq, date_created, priority, eta):
+        self.uuid = uuid
+        self.channel = channel
+        self.seq = seq
+        self.date_created = date_created
+        self.priority = priority
+        self.eta = eta
+
+    def __repr__(self):
+        return "<ChannelJob %s>" % self.uuid
+
+    def __eq__(self, other):
+        return id(self) == id(other)
+
+    def __hash__(self):
+        return id(self)
+
+    def __cmp__(self, other):
+        if self.eta and not other.eta:
+            return -1
+        elif not self.eta and other.eta:
+            return 1
+        else:
+            return (cmp(self.eta, other.eta) or
+                    cmp(self.priority, other.priority) or
+                    cmp(self.date_created, other.date_created))
+
+
+class ChannelQueue:
+    """A channel queue is a priority queue for jobs, that returns
+    jobs with a past ETA first.
+
+    >>> q = ChannelQueue()
+    >>> j1 = ChannelJob(None, 1, seq=0, date_created=1, priority=1, eta=10)
+    >>> j2 = ChannelJob(None, 2, seq=0, date_created=2, priority=1, eta=None)
+    >>> j3 = ChannelJob(None, 3, seq=0, date_created=3, priority=1, eta=None)
+    >>> q.add(j1)
+    >>> q.add(j2)
+    >>> q.add(j3)
+    >>> q.pop(now=1)
+    <ChannelJob 2>
+    >>> q.pop(now=11)
+    <ChannelJob 1>
+    >>> q.pop(now=12)
+    <ChannelJob 3>
+    """
+
+    def __init__(self):
+        self._queue = PriorityQueue()
+        self._eta_queue = PriorityQueue()
+
+    def __len__(self):
+        return len(self._eta_queue) + len(self._queue)
+
+    def __contains__(self, o):
+        return o in self._eta_queue or o in self._queue
+
+    def add(self, job):
+        if job.eta:
+            self._eta_queue.add(job)
+        else:
+            self._queue.add(job)
+
+    def remove(self, job):
+        self._eta_queue.remove(job)
+        self._queue.remove(job)
+
+    def pop(self, now):
+        if len(self._eta_queue) and self._eta_queue[0].eta <= now:
+            return self._eta_queue.pop()
+        else:
+            return self._queue.pop()
+
+
+class Channel:
+
+    def __init__(self, name, parent, workers=1, sequential=False):
+        self.name = name
+        self.parent = parent
+        if self.parent:
+            self.parent.children.append(self)
+        self.children = []
+        self.workers = workers
+        if sequential and workers != 1:
+            raise ValueError("A sequential channel can have only one worker")
+        self.sequential = sequential
+        self._queue = ChannelQueue()
+        self._running = SafeSet()
+        self._failed = SafeSet()
+
+    def __str__(self):
+        return "%s(Q:%d,R:%d,F:%d)" % (self.name,
+                                       len(self._queue),
+                                       len(self._running),
+                                       len(self._failed))
+
+    def remove(self, job):
+        self._queue.remove(job)
+        self._running.remove(job)
+        self._failed.remove(job)
+        if self.parent:
+            self.parent.remove(job)
+
+    def set_done(self, job):
+        self.remove(job)
+        _logger.debug("job %s marked done", job.uuid)
+
+    def set_pending(self, job):
+        if job not in self._queue:
+            self._queue.add(job)
+            self._running.remove(job)
+            self._failed.remove(job)
+            if self.parent:
+                self.parent.remove(job)
+            _logger.debug("job %s marked pending", job.uuid)
+
+    def set_running(self, job):
+        if job not in self._running:
+            self._queue.remove(job)
+            self._running.add(job)
+            self._failed.remove(job)
+            if self.parent:
+                self.parent.set_running(job)
+            _logger.debug("job %s marked running", job.uuid)
+
+    def set_failed(self, job):
+        if job not in self._failed:
+            self._queue.remove(job)
+            self._running.remove(job)
+            self._failed.add(job)
+            if self.parent:
+                self.parent.remove(job)
+            _logger.debug("job %s marked failed", job.uuid)
+
+    def get_jobs_to_run(self):
+        # enqueue jobs of children channels
+        for child in self.children:
+            for job in child.get_jobs_to_run():
+                self._queue.add(job)
+        # sequential channels block when there are failed jobs
+        if self.sequential and len(self._failed):
+            return
+        # yield jobs that are ready to run
+        while len(self._running) < self.workers:
+            job = self._queue.pop(now=datetime.now())
+            if not job:
+                return
+            self._running.add(job)
+            _logger.debug("job %s marked running", job.uuid)
+            yield job
+
+
+class ChannelManager:
+
+    def __init__(self, workers):
+        # TODO: config
+        self._jobs_by_uuid = WeakValueDictionary()
+        self._root_channel = Channel(name='root', parent=None, workers=workers)
+
+    def get_channel_by_name(self, channel_name):
+        # TODO: channels by name
+        # TODO: autocreate/autodestroy channels
+        return self._root_channel
+
+    def notify(self, channel_name, uuid,
+               seq, date_created, priority, eta, state):
+        channel = self.get_channel_by_name(channel_name)
+        job = self._jobs_by_uuid.get(uuid)
+        if not job:
+            job = ChannelJob(channel, uuid, seq, date_created, priority, eta)
+            self._jobs_by_uuid[uuid] = job
+        # TODO: handle sequence change
+        assert job.seq == seq
+        # date_created is invariant
+        assert job.date_created == date_created
+        # TODO: handle priority change
+        assert job.priority == priority
+        # TODO: handle eta change
+        assert job.eta == eta
+        # TODO: handle channel change
+        assert job.channel == channel
+        # state transitions
+        if not state or state == STATE_DONE:
+            channel.set_done(job)
+        elif state == STATE_PENDING:
+            channel.set_pending(job)
+        elif state in (STATE_ENQUEUED, STATE_STARTED):
+            channel.set_running(job)
+        elif state == STATE_FAILED:
+            channel.set_failed(job)
+        else:
+            _logger.error("unexpected state %s for job %s", state, job)
+        _logger.debug("channel %s", self._root_channel)
+
+    def get_jobs_to_run(self):
+        for job in self._root_channel.get_jobs_to_run():
+            yield job
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/connector/channels.py
+++ b/connector/channels.py
@@ -283,16 +283,16 @@ class Channel:
     limit (= workers). Channels are joined together in a downstream channel
     and the flow limit of the downstream channel limit upstream channels.
 
-    ---------------------\
-                         \
-                         \-----------------------
-     Ch. A W:4,Q:12,R:4
-
-    ---------------------\  Ch. root W:5,Q:0,R:4
+    ---------------------+
                          |
-    ---------------------/
-     Ch. B W:1,Q:0,R:0    -----------------------
-    ---------------------/
+                         |
+     Ch. A W:4,Q:12,R:4  +-----------------------
+
+    ---------------------+  Ch. root W:5,Q:0,R:4
+                         |
+    ---------------------+
+     Ch. B W:1,Q:0,R:0
+    ---------------------+-----------------------
 
     The above diagram illustrates two channels joining in the root channel.
     The root channel has 5 workers, and 4 running jobs coming from Channel A.
@@ -380,6 +380,10 @@ class Channel:
             for job in child.get_jobs_to_run():
                 self._queue.add(job)
         # sequential channels block when there are failed jobs
+        # TODO: this is probably not sufficient to ensure
+        #       senquentiality because of the behaviour in presence
+        #       of jobs with eta; plus: check if there are no
+        #       race conditions.
         if self.sequential and len(self._failed):
             return
         # yield jobs that are ready to run

--- a/connector/connector.py
+++ b/connector/connector.py
@@ -83,6 +83,10 @@ def install_in_connector():
 install_in_connector()
 
 
+def is_module_installed(pool, module_name):
+    return bool(pool.get('%s.installed' % module_name))
+
+
 def get_openerp_module(cls_or_func):
     """ For a top level function or class, returns the
     name of the OpenERP module where it lives.

--- a/connector/connector_menu.xml
+++ b/connector/connector_menu.xml
@@ -13,12 +13,24 @@
             name="Queue"
             parent="menu_connector_root"/>
 
+        <menuitem id="menu_queue_job_channel"
+            action="action_queue_job_channel"
+            sequence="12"
+            parent="menu_queue"/>
+
+        <menuitem id="menu_queue_job_function"
+            action="action_queue_job_function"
+            sequence="14"
+            parent="menu_queue"/>
+
         <menuitem id="menu_queue_worker"
             action="action_queue_worker"
+            sequence="16"
             parent="menu_queue"/>
 
         <menuitem id="menu_queue_job"
             action="action_queue_job"
+            sequence="18"
             parent="menu_queue"/>
 
         <menuitem id="menu_checkpoint"

--- a/connector/controllers/__init__.py
+++ b/connector/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -42,8 +42,8 @@ class RunJobController(http.Controller):
             raise
         return job
 
-    @http.route('/runjob', type='http', auth='none')
-    def handler(self, db, job_uuid, **kw):
+    @http.route('/connector/runjob', type='http', auth='none')
+    def runjob(self, db, job_uuid, **kw):
 
         session_hdl = ConnectorSessionHandler(db,
                                               openerp.SUPERUSER_ID)

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -79,11 +79,9 @@ class RunJobController(http.Controller):
             _logger.debug('%s started', job)
             with session_hdl.session() as session:
                 job.perform(session)
-            _logger.debug('%s done', job)
-
-            with session_hdl.session() as session:
                 job.set_done()
                 self.job_storage_class(session).store(job)
+            _logger.debug('%s done', job)
 
         except NothingToDoJob as err:
             if unicode(err):

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -60,10 +60,13 @@ class RunJobController(http.Controller):
                 return ""
 
         try:
-            # if the job has been manually set to DONE or PENDING
+            # if the job has been manually set to DONE or PENDING,
+            # or if something tries to run a job that is not enqueued
             # before its execution, stop
-            # TODO: is this still possible?
             if job.state != ENQUEUED:
+                _logger.warning('job %s is in state %s '
+                                'instead of enqueued in /runjob',
+                                job.state, job_uuid)
                 return
 
             with session_hdl.session() as session:

--- a/connector/doc/api/api_channels.rst
+++ b/connector/doc/api/api_channels.rst
@@ -1,0 +1,14 @@
+########
+Channels
+########
+
+This is the API documentation for the job channels and the
+scheduling mechanisms of the job runner.
+
+These classes are not intended for use by module developers.
+
+.. automodule:: connector.jobrunner.channels
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/connector/doc/api/api_runner.rst
+++ b/connector/doc/api/api_runner.rst
@@ -1,0 +1,13 @@
+##########
+Job Runner
+##########
+
+This is the API documentation for the job runner.
+
+These classes are not intended for use by module developers.
+
+.. automodule:: connector.jobrunner.runner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/connector/doc/guides/jobrunner.rst
+++ b/connector/doc/guides/jobrunner.rst
@@ -1,0 +1,33 @@
+.. _jobrunner:
+
+
+#######################################
+Configuring channels and the job runner
+#######################################
+
+.. automodule:: connector.jobrunner.runner
+
+What is a channel?
+------------------
+
+.. autoclass:: connector.jobrunner.channels.Channel
+
+How to configure Channels?
+--------------------------
+
+The ``ODOO_CONNECTOR_CHANNELS`` environment variable must be
+set before starting Odoo in order to enable the job runner
+and configure the capacity of the channels.
+
+The general syntax is ``channel(.subchannel)*(:capacity(:key(=value)?)*)?,...``.
+
+Intermediate subchannels which are not configured explicitly are autocreated
+with an unlimited capacity (except the root channel which if not configured gets
+a default capacity of 1).
+
+Example ``ODOO_CONNECTOR_CHANNELS``:
+
+* ``root:4``: allow up to 4 concurrent jobs in the root channel.
+* ``root:4,root.sub:2``: allow up to 4 concurrent jobs in the root channel and
+  up to 2 concurrent jobs in the channel named ``root.sub``.
+* ``sub:2``: the same.

--- a/connector/doc/guides/multiprocessing.rst
+++ b/connector/doc/guides/multiprocessing.rst
@@ -1,9 +1,16 @@
 .. _multiprocessing:
 
 
-######################################
-Use the connector with multiprocessing
-######################################
+##############################################
+Use the connector with multiprocessing workers
+##############################################
+
+.. note:: In a future version, workers will be deprecated
+          in favor of the newer job runner which is more efficient and
+          supports job channels. You should try the job runner first
+          and fall back to using workers in case the runner does not
+          work (sic) for you, in which case we will very much appreciate
+          a github issue describing the problems you encoutered.
 
 When Odoo is launched with 1 process, the jobs worker will run
 threaded in the same process.

--- a/connector/doc/guides/multiprocessing.rst
+++ b/connector/doc/guides/multiprocessing.rst
@@ -10,7 +10,7 @@ Use the connector with multiprocessing workers
           supports job channels. You should try the job runner first
           and fall back to using workers in case the runner does not
           work (sic) for you, in which case we will very much appreciate
-          a github issue describing the problems you encoutered.
+          a github issue describing the problems you encountered.
 
 When Odoo is launched with 1 process, the jobs worker will run
 threaded in the same process.

--- a/connector/doc/index.rst
+++ b/connector/doc/index.rst
@@ -16,7 +16,7 @@ ability to be extended with additional modules for new features or
 customizations.
 
 The development of Odoo Connector has been started by `Camptocamp`_ and is now
-maintained by `Camptocamp`_, `Akretion`_ and several :ref:`contributors`.
+maintained by `Camptocamp`_, `Akretion`_, `Acsone`_ and several :ref:`contributors`.
 
 *Subscribe to the* `project's mailing list`_
 
@@ -39,6 +39,7 @@ Core Features
 .. _Odoo: http://www.odoo.com
 .. _Camptocamp: http://www.camptocamp.com
 .. _Akretion: http://www.akretion.com
+.. _Acsone: http://www.acsone.eu
 .. _`source code is available on GitHub`: https://github.com/OCA/connector
 .. _`AGPL version 3`: http://www.gnu.org/licenses/agpl-3.0.html
 .. _`project's mailing list`: https://launchpad.net/~openerp-connector-community
@@ -112,6 +113,7 @@ Developer's guide
    guides/code_overview.rst
    guides/concepts.rst
    guides/bootstrap_connector.rst
+   guides/jobrunner.rst
    guides/multiprocessing.rst
 
 API Reference
@@ -130,6 +132,8 @@ API Reference
    api/api_backend_adapter.rst
    api/api_queue.rst
    api/api_exception.rst
+   api/api_channels.rst
+   api/api_runner.rst
 
 ******************
 Indices and tables

--- a/connector/exception.py
+++ b/connector/exception.py
@@ -75,3 +75,7 @@ class IDMissingInBackend(JobError):
 
 class ManyIDSInBackend(JobError):
     """Unique key exists many times in backend"""
+
+
+class ChannelNotFound(ConnectorException):
+    """ A channel could not be found """

--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -1,11 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of connector, an Odoo module.
+#
+#     Author: Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     connector is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     connector is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with connector.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
 import logging
+import os
 from threading import Thread
 import time
 
-from openerp.service import db
 from openerp.service import server
+from openerp.tools import config
 
-from . import channels
 from .runner import OdooConnectorRunner
 
 _logger = logging.getLogger(__name__)
@@ -13,16 +38,26 @@ _logger = logging.getLogger(__name__)
 START_DELAY = 10
 
 
+# Here we monkey patch the Odoo server to start the job runner thread
+# in the main server process (and not in forked workers). This is
+# very easy to deploy as we don't need another startup script.
+# The drawback is that it is not possible to extend the Odoo
+# server command line arguments, so we resort to environment variables
+# to configure the runner (channels mostly).
+
+
+# TODO: this is a temporary flag to enable the connector runner
+enable = os.environ.get('ODOO_CONNECTOR_RUNNER_ENABLE')
+
+
 def run():
     # sleep a bit to let the workers start at ease
     time.sleep(START_DELAY)
-    _logger.info("dbs: %s", db.exp_list())
-    OdooConnectorRunner().run_forever()
+    port = os.environ.get('ODOO_CONNECTOR_PORT') or config['xmlrpc_port']
+    channels = os.environ.get('ODOO_CONNECTOR_CHANNELS')
+    runner = OdooConnectorRunner(port or 8069, channels or 'root:1')
+    runner.run_forever()
 
-
-# monkey patch the Odoo server to start the job runner thread
-# once in the main process and in the main process only
-# (ie not in forked workers)
 
 orig_prefork_start = server.PreforkServer.start
 orig_threaded_start = server.ThreadedServer.start
@@ -31,27 +66,30 @@ orig_gevent_start = server.GeventServer.start
 
 def prefork_start(server, *args, **kwargs):
     res = orig_prefork_start(server, *args, **kwargs)
-    _logger.error("jobrunner prefork start")
-    thread = Thread(target=run)
-    thread.daemon = True
-    thread.start()
+    if enable and not config['stop_after_init']:
+        _logger.info("starting jobrunner thread (in prefork server)")
+        thread = Thread(target=run)
+        thread.daemon = True
+        thread.start()
     return res
 
 
 def threaded_start(server, *args, **kwargs):
     res = orig_threaded_start(server, *args, **kwargs)
-    _logger.error("jobrunner threaded start")
-    thread = Thread(target=run)
-    thread.daemon = True
-    thread.start()
+    if enable and not config['stop_after_init']:
+        _logger.info("starting jobrunner thread (in threaded server)")
+        thread = Thread(target=run)
+        thread.daemon = True
+        thread.start()
     return res
 
 
 def gevent_start(server, *args, **kwargs):
     res = orig_gevent_start(server, *args, **kwargs)
-    _logger.error("jobrunner gevent start")
-    # TODO: gevent spawn?
-    raise RuntimeError("not implemented")
+    if enable and not config['stop_after_init']:
+        _logger.info("starting jobrunner thread (in gevent server)")
+        # TODO: gevent spawn?
+        raise RuntimeError("not implemented")
     return res
 
 

--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -46,8 +46,7 @@ START_DELAY = 5
 # to configure the runner (channels mostly).
 
 
-# TODO: this is a temporary flag to enable the connector runner
-enable = os.environ.get('ODOO_CONNECTOR_RUNNER_ENABLE')
+enable = os.environ.get('ODOO_CONNECTOR_CHANNELS')
 
 
 def run():

--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -35,7 +35,7 @@ from .runner import OdooConnectorRunner
 
 _logger = logging.getLogger(__name__)
 
-START_DELAY = 10
+START_DELAY = 5
 
 
 # Here we monkey patch the Odoo server to start the job runner thread

--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -31,7 +31,7 @@ import time
 from openerp.service import server
 from openerp.tools import config
 
-from .runner import OdooConnectorRunner
+from .runner import ConnectorRunner
 
 _logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def run():
     time.sleep(START_DELAY)
     port = os.environ.get('ODOO_CONNECTOR_PORT') or config['xmlrpc_port']
     channels = os.environ.get('ODOO_CONNECTOR_CHANNELS')
-    runner = OdooConnectorRunner(port or 8069, channels or 'root:1')
+    runner = ConnectorRunner(port or 8069, channels or 'root:1')
     runner.run_forever()
 
 

--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -1,0 +1,60 @@
+import logging
+from threading import Thread
+import time
+
+from openerp.service import db
+from openerp.service import server
+
+from . import channels
+from .runner import OdooConnectorRunner
+
+_logger = logging.getLogger(__name__)
+
+START_DELAY = 10
+
+
+def run():
+    # sleep a bit to let the workers start at ease
+    time.sleep(START_DELAY)
+    _logger.info("dbs: %s", db.exp_list())
+    OdooConnectorRunner().run_forever()
+
+
+# monkey patch the Odoo server to start the job runner thread
+# once in the main process and in the main process only
+# (ie not in forked workers)
+
+orig_prefork_start = server.PreforkServer.start
+orig_threaded_start = server.ThreadedServer.start
+orig_gevent_start = server.GeventServer.start
+
+
+def prefork_start(server, *args, **kwargs):
+    res = orig_prefork_start(server, *args, **kwargs)
+    _logger.error("jobrunner prefork start")
+    thread = Thread(target=run)
+    thread.daemon = True
+    thread.start()
+    return res
+
+
+def threaded_start(server, *args, **kwargs):
+    res = orig_threaded_start(server, *args, **kwargs)
+    _logger.error("jobrunner threaded start")
+    thread = Thread(target=run)
+    thread.daemon = True
+    thread.start()
+    return res
+
+
+def gevent_start(server, *args, **kwargs):
+    res = orig_gevent_start(server, *args, **kwargs)
+    _logger.error("jobrunner gevent start")
+    # TODO: gevent spawn?
+    raise RuntimeError("not implemented")
+    return res
+
+
+server.PreforkServer.start = prefork_start
+server.ThreadedServer.start = threaded_start
+server.GeventServer.start = gevent_start

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -197,9 +197,11 @@ class ChannelJob:
     True
     """
 
-    def __init__(self, channel, uuid, seq, date_created, priority, eta):
-        self.uuid = uuid
+    def __init__(self, db_name, channel, uuid,
+                 seq, date_created, priority, eta):
+        self.db_name = db_name
         self.channel = channel
+        self.uuid = uuid
         self.seq = seq
         self.date_created = date_created
         self.priority = priority
@@ -528,7 +530,7 @@ class ChannelManager:
             parent = subchannel
         return parent
 
-    def notify(self, channel_config_string, uuid,
+    def notify(self, db_name, channel_config_string, uuid,
                seq, date_created, priority, eta, state):
         if not channel_config_string:
             channel = self._root_channel
@@ -540,10 +542,13 @@ class ChannelManager:
             channel = self.get_channel_from_config(configs[0])
         job = self._jobs_by_uuid.get(uuid)
         if not job:
-            job = ChannelJob(channel, uuid, seq, date_created, priority, eta)
+            job = ChannelJob(db_name, channel, uuid,
+                             seq, date_created, priority, eta)
             self._jobs_by_uuid[uuid] = job
         # TODO: handle sequence change
         assert job.seq == seq
+        # db_name is invariant
+        assert job.db_name == db_name
         # date_created is invariant
         assert job.date_created == date_created
         # TODO: handle priority change

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -28,16 +28,10 @@ from heapq import heappush, heappop
 import logging
 from weakref import WeakValueDictionary
 
+from ..queue.job import PENDING, ENQUEUED, STARTED, FAILED, DONE
+NOT_DONE = (PENDING, ENQUEUED, STARTED, FAILED)
+
 _logger = logging.getLogger(__name__)
-
-
-STATE_PENDING = 'pending'
-STATE_ENQUEUED = 'enqueued'
-STATE_STARTED = 'started'
-STATE_FAILED = 'failed'
-STATE_DONE = 'done'
-
-STATES_NOT_DONE = (STATE_PENDING, STATE_ENQUEUED, STATE_STARTED, STATE_FAILED)
 
 
 class PriorityQueue:
@@ -575,13 +569,13 @@ class ChannelManager:
         # TODO: handle channel change
         assert job.channel == channel
         # state transitions
-        if not state or state == STATE_DONE:
+        if not state or state == DONE:
             channel.set_done(job)
-        elif state == STATE_PENDING:
+        elif state == PENDING:
             channel.set_pending(job)
-        elif state in (STATE_ENQUEUED, STATE_STARTED):
+        elif state in (ENQUEUED, STARTED):
             channel.set_running(job)
-        elif state == STATE_FAILED:
+        elif state == FAILED:
             channel.set_failed(job)
         else:
             _logger.error("unexpected state %s for job %s", state, job)

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -302,12 +302,12 @@ class Channel(object):
         ---------------------+
                              |
                              |
-         Ch. A W:4,Q:12,R:4  +-----------------------
+         Ch. A C:4,Q:12,R:4  +-----------------------
 
-        ---------------------+  Ch. root W:5,Q:0,R:4
+        ---------------------+  Ch. root C:5,Q:0,R:4
                              |
         ---------------------+
-         Ch. B W:1,Q:0,R:0
+         Ch. B C:1,Q:0,R:0
         ---------------------+-----------------------
 
     The above diagram illustrates two channels joining in the root channel.
@@ -369,7 +369,7 @@ class Channel(object):
         return self.children.get(subchannel_name)
 
     def __str__(self):
-        return "%s(W:%d,Q:%d,R:%d,F:%d)" % (self.fullname,
+        return "%s(C:%d,Q:%d,R:%d,F:%d)" % (self.fullname,
                                             self.capacity,
                                             len(self._queue),
                                             len(self._running),
@@ -505,7 +505,7 @@ class ChannelManager(object):
     [<ChannelJob B1>, <ChannelJob A1>, <ChannelJob A2>, <ChannelJob A3>]
 
     Job A2 is done. Next job to run is A5, even if we have
-    higher priority job in channel B, because channel B as a capacity of 1.
+    higher priority job in channel B, because channel B has a capacity of 1.
 
     >>> cm.notify(db, 'A', 'A2', 2, 0, 10, None, 'done')
     >>> pp(list(cm.get_jobs_to_run(now=100)))

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -28,6 +28,8 @@ from heapq import heappush, heappop
 import logging
 from weakref import WeakValueDictionary
 
+from openerp.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+
 from ..exception import ChannelNotFound
 from ..queue.job import PENDING, ENQUEUED, STARTED, FAILED, DONE
 NOT_DONE = (PENDING, ENQUEUED, STARTED, FAILED)
@@ -414,8 +416,9 @@ class Channel(object):
         if self.sequential and len(self._failed):
             return
         # yield jobs that are ready to run
+        now = datetime.now().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         while not self.capacity or len(self._running) < self.capacity:
-            job = self._queue.pop(now=datetime.now())
+            job = self._queue.pop(now)
             if not job:
                 return
             self._running.add(job)

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -154,6 +154,7 @@ class ChannelJob(object):
     Here are some examples.
 
     j1 comes before j2 before it has a smaller date_created
+
     >>> j1 = ChannelJob(None, None, 1,
     ...                 seq=0, date_created=1, priority=9, eta=None)
     >>> j1
@@ -165,12 +166,14 @@ class ChannelJob(object):
 
     j3 comes first because it has lower priority,
     despite having a creation date after j1 and j2
+
     >>> j3 = ChannelJob(None, None, 3,
     ...                 seq=0, date_created=3, priority=2, eta=None)
     >>> j3 < j1
     True
 
     j4 and j5 comes even before j3, because they have an eta
+
     >>> j4 = ChannelJob(None, None, 4,
     ...                 seq=0, date_created=4, priority=9, eta=9)
     >>> j5 = ChannelJob(None, None, 5,
@@ -179,17 +182,20 @@ class ChannelJob(object):
     True
 
     j6 has same date_created and priority as j5 but a smaller eta
+
     >>> j6 = ChannelJob(None, None, 6,
     ...                 seq=0, date_created=5, priority=9, eta=2)
     >>> j6 < j4 < j5
     True
 
     Here is the complete suite:
+
     >>> j6 < j4 < j5 < j3 < j1 < j2
     True
 
     j0 has the same properties as j1 but they are not considered
     equal as they are different instances
+
     >>> j0 = ChannelJob(None, None, 1,
     ...                 seq=0, date_created=1, priority=9, eta=None)
     >>> j0 == j1
@@ -340,7 +346,8 @@ class Channel(object):
     def configure(self, config):
         """ Configure a channel from a dictionary.
 
-        Avaiable keys are:
+        Supported keys are:
+
         * capacity
         * sequential
         """

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -371,7 +371,7 @@ class Channel(object):
     def set_done(self, job):
         self.remove(job)
         _logger.debug("job %s marked done in channel %s",
-                      job.uuid, self.fullname)
+                      job.uuid, self)
 
     def set_pending(self, job):
         if job not in self._queue:
@@ -381,7 +381,7 @@ class Channel(object):
             if self.parent:
                 self.parent.remove(job)
             _logger.debug("job %s marked pending in channel %s",
-                          job.uuid, self.fullname)
+                          job.uuid, self)
 
     def set_running(self, job):
         if job not in self._running:
@@ -391,7 +391,7 @@ class Channel(object):
             if self.parent:
                 self.parent.set_running(job)
             _logger.debug("job %s marked running in channel %s",
-                          job.uuid, self.fullname)
+                          job.uuid, self)
 
     def set_failed(self, job):
         if job not in self._failed:
@@ -401,7 +401,7 @@ class Channel(object):
             if self.parent:
                 self.parent.remove(job)
             _logger.debug("job %s marked failed in channel %s",
-                          job.uuid, self.fullname)
+                          job.uuid, self)
 
     def get_jobs_to_run(self):
         # enqueue jobs of children channels
@@ -423,8 +423,7 @@ class Channel(object):
                 return
             self._running.add(job)
             _logger.debug("job %s marked running in channel %s",
-                          job.uuid, self.fullname)
-            _logger.debug("channel %s", self)
+                          job.uuid, self)
             yield job
 
 

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -224,7 +224,8 @@ class ChannelJob:
         else:
             return (cmp(self.eta, other.eta) or
                     cmp(self.priority, other.priority) or
-                    cmp(self.date_created, other.date_created))
+                    cmp(self.date_created, other.date_created) or
+                    cmp(self.seq, other.seq))
 
 
 class ChannelQueue:

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -570,6 +570,16 @@ class ChannelManager:
             _logger.error("unexpected state %s for job %s", state, job)
         # _logger.debug("channel %s", self._root_channel)
 
+    def remove_job(self, uuid):
+        job = self._jobs_by_uuid.get(uuid)
+        if job:
+            job.channel.remove(job)
+
+    def remove_db(self, db_name):
+        for job in self._jobs_by_uuid.values():
+            if job.db_name == db_name:
+                job.channel.remove(job)
+
     def get_jobs_to_run(self):
         return self._root_channel.get_jobs_to_run()
 

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -353,7 +353,7 @@ class Channel(object):
         return self.children.get(subchannel_name)
 
     def __str__(self):
-        return "%s(W:%d,Q:%d,R:%d,F:%d)" % (self.name,
+        return "%s(W:%d,Q:%d,R:%d,F:%d)" % (self.fullname,
                                             self.capacity,
                                             len(self._queue),
                                             len(self._running),
@@ -369,7 +369,7 @@ class Channel(object):
     def set_done(self, job):
         self.remove(job)
         _logger.debug("job %s marked done in channel %s",
-                      job.uuid, self.name)
+                      job.uuid, self.fullname)
 
     def set_pending(self, job):
         if job not in self._queue:
@@ -379,7 +379,7 @@ class Channel(object):
             if self.parent:
                 self.parent.remove(job)
             _logger.debug("job %s marked pending in channel %s",
-                          job.uuid, self.name)
+                          job.uuid, self.fullname)
 
     def set_running(self, job):
         if job not in self._running:
@@ -389,7 +389,7 @@ class Channel(object):
             if self.parent:
                 self.parent.set_running(job)
             _logger.debug("job %s marked running in channel %s",
-                          job.uuid, self.name)
+                          job.uuid, self.fullname)
 
     def set_failed(self, job):
         if job not in self._failed:
@@ -399,7 +399,7 @@ class Channel(object):
             if self.parent:
                 self.parent.remove(job)
             _logger.debug("job %s marked failed in channel %s",
-                          job.uuid, self.name)
+                          job.uuid, self.fullname)
 
     def get_jobs_to_run(self):
         # enqueue jobs of children channels
@@ -420,7 +420,7 @@ class Channel(object):
                 return
             self._running.add(job)
             _logger.debug("job %s marked running in channel %s",
-                          job.uuid, self.name)
+                          job.uuid, self.fullname)
             _logger.debug("channel %s", self)
             yield job
 

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -584,7 +584,12 @@ class ChannelManager(object):
             if len(configs) != 1:
                 raise ValueError('%s is not a configuration for '
                                  'a single channel' % channel_config_string)
-            channel = self.get_channel_from_config(configs[0])
+            config = configs[0]
+            if config['name'] == 'root':
+                # don't let applications reconfigure the root channel
+                channel = self.get_channel_by_name(config['name'])
+            else:
+                channel = self.get_channel_from_config(config)
         job = self._jobs_by_uuid.get(uuid)
         if not job:
             job = ChannelJob(db_name, channel, uuid,

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -154,27 +154,33 @@ class ChannelJob:
     Here are some examples.
 
     j1 comes before j2 before it has a smaller date_created
-    >>> j1 = ChannelJob(None, 1, seq=0, date_created=1, priority=9, eta=None)
+    >>> j1 = ChannelJob(None, None, 1,
+    ...                 seq=0, date_created=1, priority=9, eta=None)
     >>> j1
     <ChannelJob 1>
-    >>> j2 = ChannelJob(None, 2, seq=0, date_created=2, priority=9, eta=None)
+    >>> j2 = ChannelJob(None, None, 2,
+    ...                 seq=0, date_created=2, priority=9, eta=None)
     >>> j1 < j2
     True
 
     j3 comes first because it has lower priority,
     despite having a creation date after j1 and j2
-    >>> j3 = ChannelJob(None, 3, seq=0, date_created=3, priority=2, eta=None)
+    >>> j3 = ChannelJob(None, None, 3,
+    ...                 seq=0, date_created=3, priority=2, eta=None)
     >>> j3 < j1
     True
 
     j4 and j5 comes even before j3, because they have an eta
-    >>> j4 = ChannelJob(None, 4, seq=0, date_created=4, priority=9, eta=9)
-    >>> j5 = ChannelJob(None, 5, seq=0, date_created=5, priority=9, eta=9)
+    >>> j4 = ChannelJob(None, None, 4,
+    ...                 seq=0, date_created=4, priority=9, eta=9)
+    >>> j5 = ChannelJob(None, None, 5,
+    ...                 seq=0, date_created=5, priority=9, eta=9)
     >>> j4 < j5 < j3
     True
 
     j6 has same date_created and priority as j5 but a smaller eta
-    >>> j6 = ChannelJob(None, 6, seq=0, date_created=5, priority=9, eta=2)
+    >>> j6 = ChannelJob(None, None, 6,
+    ...                 seq=0, date_created=5, priority=9, eta=2)
     >>> j6 < j4 < j5
     True
 
@@ -184,7 +190,8 @@ class ChannelJob:
 
     j0 has the same properties as j1 but they are not considered
     equal as they are different instances
-    >>> j0 = ChannelJob(None, 1, seq=0, date_created=1, priority=9, eta=None)
+    >>> j0 = ChannelJob(None, None, 1,
+    ...                 seq=0, date_created=1, priority=9, eta=None)
     >>> j0 == j1
     False
     >>> j0 == j0
@@ -227,9 +234,12 @@ class ChannelQueue:
     jobs with a past ETA first.
 
     >>> q = ChannelQueue()
-    >>> j1 = ChannelJob(None, 1, seq=0, date_created=1, priority=1, eta=10)
-    >>> j2 = ChannelJob(None, 2, seq=0, date_created=2, priority=1, eta=None)
-    >>> j3 = ChannelJob(None, 3, seq=0, date_created=3, priority=1, eta=None)
+    >>> j1 = ChannelJob(None, None, 1,
+    ...                 seq=0, date_created=1, priority=1, eta=10)
+    >>> j2 = ChannelJob(None, None, 2,
+    ...                 seq=0, date_created=2, priority=1, eta=None)
+    >>> j3 = ChannelJob(None, None, 3,
+    ...                 seq=0, date_created=3, priority=1, eta=None)
     >>> q.add(j1)
     >>> q.add(j2)
     >>> q.add(j3)
@@ -595,8 +605,3 @@ class ChannelManager:
 
     def get_jobs_to_run(self):
         return self._root_channel.get_jobs_to_run()
-
-
-if __name__ == '__main__':
-    import doctest
-    doctest.testmod()

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -34,7 +34,7 @@ NOT_DONE = (PENDING, ENQUEUED, STARTED, FAILED)
 _logger = logging.getLogger(__name__)
 
 
-class PriorityQueue:
+class PriorityQueue(object):
     """A priority queue that supports removing arbitrary objects.
 
     Adding an object already in the queue is a no op.
@@ -140,7 +140,7 @@ class SafeSet(set):
             pass
 
 
-class ChannelJob:
+class ChannelJob(object):
     """A channel job is attached to a channel and holds the properties of a
     job that are necessary to prioritise them.
 
@@ -229,7 +229,7 @@ class ChannelJob:
                     cmp(self.seq, other.seq))
 
 
-class ChannelQueue:
+class ChannelQueue(object):
     """A channel queue is a priority queue for jobs that returns
     jobs with a past ETA first.
 
@@ -278,7 +278,7 @@ class ChannelQueue:
             return self._queue.pop()
 
 
-class Channel:
+class Channel(object):
     """A channel for jobs, with a maximum number of workers.
 
     Job channels are joined in a hierarchy down to the root channel.
@@ -427,7 +427,7 @@ class Channel:
             yield job
 
 
-class ChannelManager:
+class ChannelManager(object):
 
     def __init__(self):
         self._jobs_by_uuid = WeakValueDictionary()

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -327,8 +327,8 @@ class Channel(object):
         self.name = name
         self.parent = parent
         if self.parent:
-            self.parent.children.append(self)
-        self.children = []
+            self.parent.children[name] = self
+        self.children = {}
         self.capacity = capacity
         self.sequential = sequential
         self._queue = ChannelQueue()
@@ -350,10 +350,7 @@ class Channel(object):
             return self.name
 
     def get_subchannel_by_name(self, subchannel_name):
-        for child in self.children:
-            if child.name == subchannel_name:
-                return child
-        return None
+        return self.children.get(subchannel_name)
 
     def __str__(self):
         return "%s(W:%d,Q:%d,R:%d,F:%d)" % (self.name,
@@ -406,7 +403,7 @@ class Channel(object):
 
     def get_jobs_to_run(self):
         # enqueue jobs of children channels
-        for child in self.children:
+        for child in self.children.values():
             for job in child.get_jobs_to_run():
                 self._queue.add(job)
         # sequential channels block when there are failed jobs

--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -351,7 +351,7 @@ class Channel(object):
         * capacity
         * sequential
         """
-        assert config['name'] == self.fullname
+        assert self.fullname.endswith(config['name'])
         self.capacity = config.get('capacity', None)
         self.sequential = bool(config.get('sequential', False))
         if self.sequential and self.capacity != 1:
@@ -556,7 +556,7 @@ class ChannelManager(object):
         >>> pp(ChannelManager.parse_simple_config('root'))
         [{'capacity': 1, 'name': 'root'}]
         >>> pp(ChannelManager.parse_simple_config('sub:2'))
-        [{'capacity': 2, 'name': 'root.sub'}]
+        [{'capacity': 2, 'name': 'sub'}]
         """
         res = []
         for channel_config_string in config_string.split(','):
@@ -566,8 +566,6 @@ class ChannelManager(object):
             if not name:
                 raise ValueError('Invalid channel config %s: '
                                  'missing channel name' % config_string)
-            if not name.startswith('root.') and name != 'root':
-                name = 'root.' + name
             config['name'] = name
             if len(config_items) > 1:
                 capacity = config_items[1]
@@ -609,6 +607,8 @@ class ChannelManager(object):
         4
         >>> cm.get_channel_by_name('root.autosub').capacity
         >>> cm.get_channel_by_name('root.autosub.sub').capacity
+        2
+        >>> cm.get_channel_by_name('autosub.sub').capacity
         2
         """
         for config in ChannelManager.parse_simple_config(config_string):
@@ -676,9 +676,7 @@ class ChannelManager(object):
         if not autocreate:
             raise ChannelNotFound('Channel %s not found' % channel_name)
         parent = self._root_channel
-        for subchannel_name in channel_name.split('.'):
-            if subchannel_name == 'root':
-                continue
+        for subchannel_name in channel_name.split('.')[1:]:
             subchannel = parent.get_subchannel_by_name(subchannel_name)
             if not subchannel:
                 subchannel = Channel(subchannel_name, parent, capacity=None)

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -209,7 +209,7 @@ class Database:
                        (ENQUEUED, uuid))
 
 
-class OdooConnectorRunner:
+class ConnectorRunner:
 
     def __init__(self, port=8069, channel_config_string='root:4'):
         self.port = port

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -83,9 +83,7 @@ import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import requests
 
-from openerp import sql_db
-from openerp.service import db
-from openerp.tools import config
+import openerp
 
 from .channels import ChannelManager, STATE_ENQUEUED, STATES_NOT_DONE
 
@@ -125,7 +123,7 @@ class Database:
 
     def __init__(self, db_name):
         self.db_name = db_name
-        self.conn = psycopg2.connect(sql_db.dsn(db_name)[1])
+        self.conn = psycopg2.connect(openerp.sql_db.dsn(db_name)[1])
         self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         self.has_connector = self._has_connector()
         if self.has_connector:
@@ -222,11 +220,11 @@ class OdooConnectorRunner:
                 _logger.info('connector runner ready for db %s', db_name)
 
     def get_db_names(self):
-        if config['db_name']:
-            db_names = config['db_name'].split(',')
+        if openerp.tools.config['db_name']:
+            db_names = openerp.tools.config['db_name'].split(',')
         else:
-            db_names = db.exp_list()
-        dbfilter = config['dbfilter']
+            db_names = openerp.service.db.exp_list()
+        dbfilter = openerp.tools.config['dbfilter']
         if dbfilter:
             db_names = [d for d in db_names if re.match(dbfilter, d)]
         return db_names

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -287,6 +287,8 @@ class ConnectorRunner:
             # outer loop does exception recovery
             try:
                 _logger.info("initializing database connections")
+                # TODO: how to detect new databases or databases
+                #       on which connector is installed after server start?
                 self.initialize_databases()
                 _logger.info("database connections ready")
                 # inner loop does the normal processing

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -108,7 +108,6 @@ def _async_http_get(url):
     #       asyncio, aiohttp and aiopg
     def urlopen():
         try:
-            _logger.debug("GET %s", url)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we log errors when Odoo
             # is not running at all
@@ -214,7 +213,7 @@ class OdooConnectorRunner:
         for db_name in self.get_db_names():
             db = Database(db_name)
             if not db.has_connector:
-                _logger.info('connector is not installed for db %s', db_name)
+                _logger.debug('connector is not installed for db %s', db_name)
             else:
                 self.db_by_name[db_name] = db
                 for job_data in db.select_jobs('state in %s',
@@ -237,7 +236,7 @@ class OdooConnectorRunner:
             _logger.info("asking Odoo to run job %s on db %s",
                          job.uuid, job.db_name)
             self.db_by_name[job.db_name].set_job_enqueued(job.uuid)
-            _async_http_get('http://localhost:%d'
+            _async_http_get('http://localhost:%s'
                             '/runjob?db=%s&job_uuid=%s' %
                             (self.port, job.db_name, job.uuid,))
 
@@ -250,7 +249,7 @@ class OdooConnectorRunner:
                 if job_datas:
                     self.channel_manager.notify(db_name, *job_datas[0])
                 else:
-                    self.remove_job(db_name, uuid)
+                    self.channel_manager.remove_job(db_name, uuid)
 
     def wait_notification(self):
         for db in self.db_by_name.values():

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -87,7 +87,7 @@ import requests
 
 import openerp
 
-from .channels import ChannelManager, STATE_ENQUEUED, STATES_NOT_DONE
+from .channels import ChannelManager, ENQUEUED, NOT_DONE
 
 # TODO: since STATE_ENQUEUED is now very short lived state
 #       we can automatically requeue (set pending) all
@@ -206,7 +206,7 @@ class Database:
         with closing(self.conn.cursor()) as cr:
             cr.execute("UPDATE queue_job SET state=%s, date_enqueued=NOW() "
                        "WHERE uuid=%s",
-                       (STATE_ENQUEUED, uuid))
+                       (ENQUEUED, uuid))
 
 
 class OdooConnectorRunner:
@@ -243,7 +243,7 @@ class OdooConnectorRunner:
             else:
                 self.db_by_name[db_name] = db
                 for job_data in db.select_jobs('state in %s',
-                                               (STATES_NOT_DONE,)):
+                                               (NOT_DONE,)):
                     self.channel_manager.notify(db_name, *job_data)
                 _logger.info('connector runner ready for db %s', db_name)
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -200,7 +200,8 @@ class Database(object):
     def set_job_enqueued(self, uuid):
         with closing(self.conn.cursor()) as cr:
             cr.execute("UPDATE queue_job SET state=%s, "
-                       "date_enqueued=date_trunc('seconds', now()::timestamp) "
+                       "date_enqueued=date_trunc('seconds', "
+                       "                         now() at time zone 'utc') "
                        "WHERE uuid=%s",
                        (ENQUEUED, uuid))
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -24,23 +24,22 @@
 #
 ##############################################################################
 """
-Odoo Connector jobs runner
-==========================
-
-What's this?
-------------
+What's is the job runner?
+-------------------------
 This is an alternative to connector workers, with the goal
 of resolving issues due to the polling nature of workers:
-* jobs do not start immediately even if there is a free connector worker
-* connector workers may starve while other workers have too many jobs enqueued
+
+* jobs do not start immediately even if there is a free connector worker,
+* connector workers may starve while other workers have too many jobs enqueued,
 * connector workers require another startup script,
   making deployment more difficult
 
 It is fully compatible with the connector mechanism and only
 replaces workers.
 
-How?
-----
+How does it work?
+-----------------
+
 * It starts as a thread in the Odoo main process
 * It receives postgres NOTIFY messages each time jobs are
   added or updated in the queue_job table.
@@ -49,20 +48,25 @@ How?
 * It does not run jobs itself, but asks Odoo to run them through an
   anonymous /connector/runjob HTTP request [1].
 
-How to use
-----------
-* set the following environment variables:
+How to use it?
+--------------
+
+* Set the following environment variables:
+
   - ODOO_CONNECTOR_CHANNELS=root:4 (or any other channels configuration)
   - optional if xmlrpc_port is not set: ODOO_CONNECTOR_PORT=8069
-* start Odoo with --load=web,connector and --workers > 1 [2]
-* disable "Enqueue Jobs" cron
-* do NOT start openerp-connector-worker
-* create jobs (eg using base_import_async) and observe they
-  start immediately and in parallel
 
-TODO
-----
-* See in the code below.
+* Start Odoo with --load=web,connector and --workers > 1. [2]
+* Disable then "Enqueue Jobs" cron.
+* Do NOT start openerp-connector-worker.
+* Create jobs (eg using base_import_async) and observe they
+  start immediately and in parallel.
+
+Caveat
+------
+
+* After creating a new database or installing connector on an
+  existing database, Odoo must be restarted for the runner to detect it.
 
 Notes
 -----

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -120,7 +120,7 @@ def _async_http_get(url):
     thread.start()
 
 
-class Database:
+class Database(object):
 
     def __init__(self, db_name):
         self.db_name = db_name
@@ -209,9 +209,9 @@ class Database:
                        (ENQUEUED, uuid))
 
 
-class ConnectorRunner:
+class ConnectorRunner(object):
 
-    def __init__(self, port=8069, channel_config_string='root:4'):
+    def __init__(self, port=8069, channel_config_string='root:1'):
         self.port = port
         self.channel_manager = ChannelManager()
         self.channel_manager.simple_configure(channel_config_string)

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -242,8 +242,7 @@ class ConnectorRunner:
                 _logger.debug('connector is not installed for db %s', db_name)
             else:
                 self.db_by_name[db_name] = db
-                for job_data in db.select_jobs('state in %s',
-                                               (NOT_DONE,)):
+                for job_data in db.select_jobs('state in %s', (NOT_DONE,)):
                     self.channel_manager.notify(db_name, *job_data)
                 _logger.info('connector runner ready for db %s', db_name)
 
@@ -254,7 +253,7 @@ class ConnectorRunner:
             self.db_by_name[job.db_name].set_job_enqueued(job.uuid)
             _async_http_get('http://localhost:%s'
                             '/connector/runjob?db=%s&job_uuid=%s' %
-                            (self.port, job.db_name, job.uuid,))
+                            (self.port, job.db_name, job.uuid))
 
     def process_notifications(self):
         for db in self.db_by_name.values():

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -240,7 +240,8 @@ class ConnectorRunner(object):
                 _logger.info('connector runner ready for db %s', db_name)
 
     def run_jobs(self):
-        for job in self.channel_manager.get_jobs_to_run():
+        now = openerp.fields.Datetime.now()
+        for job in self.channel_manager.get_jobs_to_run(now):
             _logger.info("asking Odoo to run job %s on db %s",
                          job.uuid, job.db_name)
             self.db_by_name[job.db_name].set_job_enqueued(job.uuid)

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -129,7 +129,6 @@ class Database(object):
         self.has_connector = self._has_connector()
         if self.has_connector:
             self.has_channel = self._has_queue_job_column('channel')
-            self.has_seq = self._has_queue_job_column('seq')
             self._initialize()
 
     def close(self):
@@ -190,10 +189,9 @@ class Database(object):
             cr.execute("LISTEN connector")
 
     def select_jobs(self, where, args):
-        query = "SELECT %s, uuid, %s, date_created, priority, eta, state " \
+        query = "SELECT %s, uuid, id as seq, date_created, priority, eta, state " \
                 "FROM queue_job WHERE %s" % \
                 ('channel' if self.has_channel else 'NULL',
-                 'seq' if self.has_seq else 0,
                  where)
         with closing(self.conn.cursor()) as cr:
             cr.execute(query, args)

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -204,7 +204,8 @@ class Database:
 
     def set_job_enqueued(self, uuid):
         with closing(self.conn.cursor()) as cr:
-            cr.execute("UPDATE queue_job SET state=%s, date_enqueued=NOW() "
+            cr.execute("UPDATE queue_job SET state=%s, "
+                       "date_enqueued=date_trunc('seconds', now()::timestamp) "
                        "WHERE uuid=%s",
                        (ENQUEUED, uuid))
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -88,12 +88,6 @@ import openerp
 
 from .channels import ChannelManager, ENQUEUED, NOT_DONE
 
-# TODO: since STATE_ENQUEUED is now very short lived state
-#       we can automatically requeue (set pending) all
-#       jobs that are enqueued since more than a few seconds
-#       this is important as jobs will be stuck in that
-#       state if this odoo-connector-runner runs while odoo does not
-
 SELECT_TIMEOUT = 60
 ERROR_RECOVERY_DELAY = 5
 
@@ -107,8 +101,7 @@ def _async_http_get(url):
     def urlopen():
         try:
             # we are not interested in the result, so we set a short timeout
-            # but not too short so we log errors when Odoo
-            # is not running at all
+            # but not too short so we trap and log hard configuration errors
             requests.get(url, timeout=1)
         except requests.Timeout:
             pass

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -47,7 +47,7 @@ How?
 * It maintains an in-memory priority queue of jobs that
   is populated from the queue_job tables in all databases.
 * It does not run jobs itself, but asks Odoo to run them through an
-  anonymous /runjob HTTP request [1].
+  anonymous /connector/runjob HTTP request [1].
 
 How to use
 ----------
@@ -253,7 +253,7 @@ class ConnectorRunner:
                          job.uuid, job.db_name)
             self.db_by_name[job.db_name].set_job_enqueued(job.uuid)
             _async_http_get('http://localhost:%s'
-                            '/runjob?db=%s&job_uuid=%s' %
+                            '/connector/runjob?db=%s&job_uuid=%s' %
                             (self.port, job.db_name, job.uuid,))
 
     def process_notifications(self):

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -52,7 +52,6 @@ How?
 How to use
 ----------
 * set the following environment variables:
-  - ODOO_CONNECTOR_RUNNER_ENABLE=1
   - ODOO_CONNECTOR_CHANNELS=root:4 (or any other channels configuration)
   - optional if xmlrpc_port is not set: ODOO_CONNECTOR_PORT=8069
 * start Odoo with --load=web,connector and --workers > 1 [2]

--- a/connector/odoo-connector-runner
+++ b/connector/odoo-connector-runner
@@ -1,4 +1,28 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of connector, an Odoo module.
+#
+#     Author: Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     connector is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     connector is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with connector.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
 """
 odoo-connector-runner
 
@@ -50,6 +74,8 @@ import requests
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+from channels import ChannelManager, STATE_ENQUEUED, STATES_NOT_DONE
+
 # TODO: This is currently working nicely but for only
 #       one database. Also, the approach is relatively
 #       brute force, as the queue_job is queried each
@@ -75,13 +101,6 @@ _TMP_DATABASE = "jobrunner-1-v80"
 _TMP_ODOO_URL = "http://localhost:8069"
 _TMP_MAX_RUNNING_JOBS = 4
 _TMP_SELECT_TIMEOUT = 60
-
-
-STATE_ENQUEUED = "enqueued"
-STATE_STARTED = "started"
-STATE_PENDING = "pending"
-STATES_RUNNING = (STATE_ENQUEUED, STATE_STARTED)
-STATES_PENDING = (STATE_PENDING,)
 
 
 # TODO: configurable
@@ -112,11 +131,12 @@ def _async_http_get(url):
 class OdooConnectorRunner:
 
     def __init__(self):
+        # TODO: config
+        self.channel_manager = ChannelManager(_TMP_MAX_RUNNING_JOBS)
         self.conn = psycopg2.connect(database=_TMP_DATABASE)
         self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with closing(self.conn.cursor()) as cr:
-            # this is the trigger that sends notifications
-            # when job states change
+            # this is the trigger that sends notifications when jobs change
             # TODO: perhaps we don't need to trigger ON DELETE?
             cr.execute("""
                 DROP TRIGGER IF EXISTS queue_job_notify ON queue_job;
@@ -124,27 +144,14 @@ class OdooConnectorRunner:
                 CREATE OR REPLACE
                     FUNCTION queue_job_notify() RETURNS trigger AS $$
                 DECLARE
-                    old_state TEXT;
-                    new_state TEXT;
-                    uuid      TEXT;
+                    uuid TEXT;
                 BEGIN
-                    IF TG_OP != 'INSERT' THEN
-                        old_state = OLD.state;
+                    IF TG_OP = 'DELETE' THEN
                         uuid = OLD.uuid;
                     ELSE
-                        old_state = '';
-                    END IF;
-                    IF TG_OP != 'DELETE' THEN
-                        new_state = NEW.state;
                         uuid = NEW.uuid;
-                    ELSE
-                        new_state = '';
                     END IF;
-                    IF new_state != old_state THEN
-                        PERFORM pg_notify('connector',
-                                          uuid || ',' ||
-                                          old_state || '->' || new_state);
-                    END IF;
+                    PERFORM pg_notify('connector', current_database() || ',' || uuid);
                     RETURN NULL;
                 END;
                 $$ LANGUAGE plpgsql;
@@ -155,55 +162,56 @@ class OdooConnectorRunner:
                     FOR EACH ROW EXECUTE PROCEDURE queue_job_notify();
             """)
             cr.execute("LISTEN connector")
+        self.notify_jobs()
 
-    def job_uuids_to_run(self):
-        # TODO: job channels https://github.com/OCA/connector/issues/43
+    def notify_jobs(self):
+        # TODO: remove all jobs for database, in case we are reconnecting
+        _logger.debug("loading all jobs")
         with closing(self.conn.cursor()) as cr:
-            cr.execute("SELECT COUNT(id) FROM queue_job WHERE state IN %s",
-                       (STATES_RUNNING,))
-            running = cr.fetchone()[0]
-            _logger.debug("there are %s running jobs", running)
-            limit = _TMP_MAX_RUNNING_JOBS - running
-            if limit > 0:
-                cr.execute("SELECT uuid FROM queue_job "
-                           "WHERE state IN %s AND active "
-                           "  AND (eta IS NULL OR eta <= NOW()) "
-                           "ORDER BY eta NULLS LAST, priority, id "
-                           "LIMIT %s",
-                           (STATES_PENDING, limit))
-                return [r[0] for r in cr.fetchall()]
+            # TODO: channel_name
+            # TODO: sequence
+            cr.execute("SELECT NULL, uuid, 0, date_created, priority, eta, state " \
+                       "  FROM queue_job WHERE state in %s", (STATES_NOT_DONE,))
+            for channel_name, uuid, seq, date_created, priority, eta, state in cr.fetchall():
+                self.channel_manager.notify(channel_name, uuid,
+                                            seq, date_created, priority, eta, state)
+        _logger.debug("loaded all jobs")
+
+    def notify_job(self, uuid):
+        with closing(self.conn.cursor()) as cr:
+            # TODO: channel_name
+            # TODO: sequence
+            cr.execute("SELECT NULL, uuid, 0, date_created, priority, eta, state " \
+                       "  FROM queue_job WHERE uuid = %s", (uuid,))
+            res = cr.fetchall()
+            if res:
+                for channel_name, uuid, seq, date_created, priority, eta, state in res:
+                    self.channel_manager.notify(channel_name, uuid,
+                                                seq, date_created, priority, eta, state)
             else:
-                _logger.debug("nothing to run")
-                return []
+                # job not found: remove it
+                _logger.warning("job %s not found in database", uuid)
+                self.channel_manager.notify(None, uuid,
+                                            None, None, None, None, None)
 
     def run_jobs(self):
         with closing(self.conn.cursor()) as cr:
-            for job_uuid in self.job_uuids_to_run():
-                _logger.debug("running job %s", job_uuid)
+            for job in self.channel_manager.get_jobs_to_run():
+                _logger.debug("asking Odoo to run job %s", job.uuid)
                 cr.execute("UPDATE queue_job "
                            "   SET state=%s, "
                            "       date_enqueued=NOW() "
                            "WHERE uuid=%s",
-                           (STATE_ENQUEUED, job_uuid))
+                           (STATE_ENQUEUED, job.uuid))
                 _async_http_get(_TMP_ODOO_URL +
                                 "/runjob?db=%s&job_uuid=%s" %
-                                (_TMP_DATABASE, job_uuid,))
+                                (_TMP_DATABASE, job.uuid,))
 
     def process_notifications(self):
-        # TODO: in this version, we don't care
-        #       about the nofifications content
-        #       and we simply query the database to see
-        #       what jobs to run; when going
-        #       multi-db, the transitions in
-        #       the notification will suffice to
-        #       decide what to run, and querying the
-        #       database will be used to re-sync
-        #       at startup.
         while self.conn.notifies:
             notification = self.conn.notifies.pop()
-            _logger.debug("got notification %s",
-                          notification.payload)
-        self.run_jobs()
+            db, uuid = notification.payload.split(',')
+            self.notify_job(uuid)
 
     def wait_notification(self):
         if self.conn.notifies:
@@ -222,6 +230,7 @@ class OdooConnectorRunner:
         while True:
             try:
                 self.process_notifications()
+                self.run_jobs()
                 self.wait_notification()
             except KeyboardInterrupt:
                 _logger.info("stopping")

--- a/connector/odoo-connector-runner
+++ b/connector/odoo-connector-runner
@@ -99,7 +99,7 @@ from channels import ChannelManager, STATE_ENQUEUED, STATES_NOT_DONE
 # TODO: make all this configurable
 _TMP_DATABASE = "jobrunner-1-v80"
 _TMP_ODOO_URL = "http://localhost:8069"
-_TMP_MAX_RUNNING_JOBS = 4
+_TMP_CONFIG = "root:4,root.sub:3"
 _TMP_SELECT_TIMEOUT = 60
 
 
@@ -131,8 +131,8 @@ def _async_http_get(url):
 class OdooConnectorRunner:
 
     def __init__(self):
-        # TODO: config
-        self.channel_manager = ChannelManager(_TMP_MAX_RUNNING_JOBS)
+        self.channel_manager = ChannelManager()
+        self.channel_manager.simple_configure(_TMP_CONFIG)
         self.conn = psycopg2.connect(database=_TMP_DATABASE)
         self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with closing(self.conn.cursor()) as cr:

--- a/connector/odoo-connector-runner
+++ b/connector/odoo-connector-runner
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+"""
+odoo-connector-runner
+
+What's this?
+============
+This is an alternative to connector workers, with the goal
+of resolving issues due to the polling nature of workers:
+* jobs do not start immediately even if there is a free worker
+* workers may starve while other workers have too many jobs enqueued
+
+It is fully compatible with the connector mechanism and only
+replaces workers.
+
+How?
+====
+* This process receives postgres NOTIFY messages each time jobs change state.
+* It does not run jobs itself, but asks Odoo to run them through an
+  anonymous HTTP request [1].
+
+How to use
+==========
+* adapt the _TMP_* variables below to suit your needs
+* start Odoo with --workers > _TMP_MAX_RUNNING_JOBS
+  and --load=web,connector
+* disable "Enqueue Jobs" cron
+* do NOT start openerp-connector-worker
+* run python odoo-connector-runner (only dependency is psycopg2)
+* create jobs (eg using base_import_async) and observe they
+  start immediately and in parallel
+
+TODO
+====
+* See in the code below.
+
+Notes
+=====
+[1] From a security standpoint, it is safe to have an anonymous HTTP
+    request because this request only accepts to run jobs that are
+    enqueued.
+"""
+
+from contextlib import closing
+import logging
+import select
+import threading
+import time
+import urllib2
+
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+# TODO: This is currently working nicely but for only
+#       one database. Also, the approach is relatively
+#       brute force, as the queue_job is queried each
+#       time a notification is received. So the next step
+#       is to maintain a in-memory list of jobs to run
+#       and use the information in the notifications to
+#       decide what to run and when. Querying the database
+#       will be done only at initialization and to re-sync
+#       the state in case of bug or missed notifications.
+#       This opens the path to a simple implementation of
+#       job channels (https://github.com/OCA/connector/issues/43).
+
+# TODO: since STATE_ENQUEUED is now very short lived state
+#       we can automatically requeue (set pending) all
+#       jobs that are enqueued since more than a few seconds
+#       this is important as jobs will be stuck in that
+#       state if this odoo-connector-runner runs while odoo does not
+
+# TODO: make all this configurable
+_TMP_DATABASE = "jobrunner-1-v80"
+_TMP_ODOO_URL = "http://localhost:8069"
+_TMP_MAX_RUNNING_JOBS = 4
+_TMP_SELECT_TIMEOUT = 60
+
+
+STATE_ENQUEUED = "enqueued"
+STATE_STARTED = "started"
+STATE_PENDING = "pending"
+STATES_RUNNING = (STATE_ENQUEUED, STATE_STARTED)
+STATES_PENDING = (STATE_PENDING,)
+
+
+# TODO: configurable
+logging.basicConfig(format='%(asctime)s %(name)s %(levelname)s:%(message)s',
+                    level=logging.DEBUG)
+_logger = logging.getLogger("odoo-connector-runner")
+
+
+def _async_http_get(url):
+    # TODO: better way to HTTP GET asynchronously (grequest, ...)?
+    #       if this was python3 I would be doing this with
+    #       asyncio, aiohttp and aiopg
+    def urlopen():
+        try:
+            _logger.debug("GET %s", url)
+            # we are not interested in the result, so we set a short timeout
+            urllib2.urlopen(url, timeout=1)
+        except:
+            pass
+    thread = threading.Thread(target=urlopen)
+    thread.daemon = True
+    thread.start()
+
+
+class OdooConnectorRunner:
+
+    def __init__(self):
+        self.conn = psycopg2.connect(database=_TMP_DATABASE)
+        self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with closing(self.conn.cursor()) as cr:
+            # this is the trigger that sends notifications
+            # when job states change
+            # TODO: perhaps we don't need to trigger ON DELETE?
+            cr.execute("""
+                DROP TRIGGER IF EXISTS queue_job_notify ON queue_job;
+
+                CREATE OR REPLACE
+                    FUNCTION queue_job_notify() RETURNS trigger AS $$
+                DECLARE
+                    old_state TEXT;
+                    new_state TEXT;
+                    uuid      TEXT;
+                BEGIN
+                    IF TG_OP != 'INSERT' THEN
+                        old_state = OLD.state;
+                        uuid = OLD.uuid;
+                    ELSE
+                        old_state = '';
+                    END IF;
+                    IF TG_OP != 'DELETE' THEN
+                        new_state = NEW.state;
+                        uuid = NEW.uuid;
+                    ELSE
+                        new_state = '';
+                    END IF;
+                    IF new_state != old_state THEN
+                        PERFORM pg_notify('connector',
+                                          uuid || ',' ||
+                                          old_state || '->' || new_state);
+                    END IF;
+                    RETURN NULL;
+                END;
+                $$ LANGUAGE plpgsql;
+
+                CREATE TRIGGER queue_job_notify
+                    AFTER INSERT OR UPDATE OR DELETE
+                    ON queue_job
+                    FOR EACH ROW EXECUTE PROCEDURE queue_job_notify();
+            """)
+            cr.execute("LISTEN connector")
+
+    def job_uuids_to_run(self):
+        # TODO: job channels https://github.com/OCA/connector/issues/43
+        with closing(self.conn.cursor()) as cr:
+            cr.execute("SELECT COUNT(id) FROM queue_job WHERE state IN %s",
+                       (STATES_RUNNING,))
+            running = cr.fetchone()[0]
+            _logger.debug("there are %s running jobs", running)
+            limit = _TMP_MAX_RUNNING_JOBS - running
+            if limit > 0:
+                cr.execute("SELECT uuid FROM queue_job "
+                           "WHERE state IN %s AND active "
+                           "  AND (eta IS NULL OR eta <= NOW()) "
+                           "ORDER BY eta NULLS LAST, priority, id "
+                           "LIMIT %s",
+                           (STATES_PENDING, limit))
+                return [r[0] for r in cr.fetchall()]
+            else:
+                _logger.debug("nothing to run")
+                return []
+
+    def run_jobs(self):
+        with closing(self.conn.cursor()) as cr:
+            for job_uuid in self.job_uuids_to_run():
+                _logger.debug("running job %s", job_uuid)
+                cr.execute("UPDATE queue_job "
+                           "   SET state=%s, "
+                           "       date_enqueued=NOW() "
+                           "WHERE uuid=%s",
+                           (STATE_ENQUEUED, job_uuid))
+                _async_http_get(_TMP_ODOO_URL +
+                                "/runjob?db=%s&job_uuid=%s" %
+                                (_TMP_DATABASE, job_uuid,))
+
+    def process_notifications(self):
+        # TODO: in this version, we don't care
+        #       about the nofifications content
+        #       and we simply query the database to see
+        #       what jobs to run; when going
+        #       multi-db, the transitions in
+        #       the notification will suffice to
+        #       decide what to run, and querying the
+        #       database will be used to re-sync
+        #       at startup.
+        while self.conn.notifies:
+            notification = self.conn.notifies.pop()
+            _logger.debug("got notification %s",
+                          notification.payload)
+        self.run_jobs()
+
+    def wait_notification(self):
+        if self.conn.notifies:
+            return
+        # wait for something to happen in the queue_job table
+        conns, _, _ = select.select([self.conn], [], [],
+                                    _TMP_SELECT_TIMEOUT)
+        if conns:
+            for conn in conns:
+                conn.poll()
+        else:
+            _logger.debug("select timeout")
+
+    def run_forever(self):
+        _logger.info("starting")
+        while True:
+            try:
+                self.process_notifications()
+                self.wait_notification()
+            except KeyboardInterrupt:
+                _logger.info("stopping")
+                break
+            except:
+                _logger.exception("exception, sleeping a bit and continuing")
+                time.sleep(1)
+
+
+if __name__ == "__main__":
+    OdooConnectorRunner().run_forever()

--- a/connector/odoo-connector-runner
+++ b/connector/odoo-connector-runner
@@ -25,7 +25,7 @@ How to use
   and --load=web,connector
 * disable "Enqueue Jobs" cron
 * do NOT start openerp-connector-worker
-* run python odoo-connector-runner (only dependency is psycopg2)
+* run python odoo-connector-runner (only dependency are psycopg2 and requests)
 * create jobs (eg using base_import_async) and observe they
   start immediately and in parallel
 
@@ -45,8 +45,8 @@ import logging
 import select
 import threading
 import time
-import urllib2
 
+import requests
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
@@ -67,6 +67,8 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 #       jobs that are enqueued since more than a few seconds
 #       this is important as jobs will be stuck in that
 #       state if this odoo-connector-runner runs while odoo does not
+
+# TODO: should we try to recover from lost postgres connections?
 
 # TODO: make all this configurable
 _TMP_DATABASE = "jobrunner-1-v80"
@@ -96,9 +98,12 @@ def _async_http_get(url):
         try:
             _logger.debug("GET %s", url)
             # we are not interested in the result, so we set a short timeout
-            urllib2.urlopen(url, timeout=1)
-        except:
+            # but not too short so we log errors when Odoo is not running at all
+            requests.get(url, timeout=1)
+        except requests.Timeout:
             pass
+        except:
+            _logger.exception("exception in GET %s", url)
     thread = threading.Thread(target=urlopen)
     thread.daemon = True
     thread.start()

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -174,6 +174,7 @@ class OpenERPJobStorage(JobStorage):
                 'date_started': False,
                 'date_done': False,
                 'eta': False,
+                'func_name': job_.func_name,
                 }
 
         dt_to_string = openerp.fields.Datetime.to_string
@@ -585,6 +586,9 @@ class Job(object):
         return self.func.related_action(session, self)
 
 
+JOB_REGISTRY = set()
+
+
 def job(func):
     """ Decorator for jobs.
 
@@ -653,6 +657,7 @@ def job(func):
             model_name=model_name,
             *args,
             **kwargs)
+    JOB_REGISTRY.add(func)
     func.delay = delay
     return func
 

--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -25,10 +25,11 @@ from datetime import datetime, timedelta
 
 from openerp import models, fields, api, exceptions, _
 
-from .job import STATES, DONE, PENDING, OpenERPJobStorage
+from .job import STATES, DONE, PENDING, OpenERPJobStorage, JOB_REGISTRY
 from .worker import WORKER_TIMEOUT
 from ..session import ConnectorSession
 from .worker import watcher
+from ..connector import get_openerp_module, is_module_installed
 
 _logger = logging.getLogger(__name__)
 
@@ -84,6 +85,21 @@ class QueueJob(models.Model):
              "max. retries.\n"
              "Retries are infinite when empty.",
     )
+    func_name = fields.Char(readonly=True)
+    job_function_id = fields.Many2one(comodel_name='queue.job.function',
+                                      compute='_compute_channel',
+                                      readonly=True,
+                                      store=True)
+    # for searching without JOIN on channels
+    channel = fields.Char(compute='_compute_channel', store=True, select=True)
+
+    @api.one
+    @api.depends('func_name', 'job_function_id.channel_id')
+    def _compute_channel(self):
+        func_model = self.env['queue.job.function']
+        function = func_model.search([('name', '=', self.func_name)])
+        self.job_function_id = function
+        self.channel = self.job_function_id.channel
 
     @api.multi
     def open_related_action(self):
@@ -388,3 +404,96 @@ class RequeueJob(models.TransientModel):
         jobs = self.job_ids
         jobs.requeue()
         return {'type': 'ir.actions.act_window_close'}
+
+
+class JobChannel(models.Model):
+    _name = 'queue.job.channel'
+    _description = 'Job Channels'
+
+    name = fields.Char()
+    complete_name = fields.Char(compute='_compute_complete_name',
+                                string='Complete Name',
+                                store=True,
+                                readonly=True)
+    parent_id = fields.Many2one(comodel_name='queue.job.channel',
+                                string='Parent Channel',
+                                ondelete='restrict')
+    job_function_ids = fields.One2many(comodel_name='queue.job.function',
+                                       inverse_name='channel_id',
+                                       string='Job Functions')
+
+    _sql_constraints = [
+        ('name_uniq',
+         'unique(complete_name)',
+         'Channel complete name must be unique'),
+    ]
+
+    @api.one
+    @api.depends('name', 'parent_id', 'parent_id.name')
+    def _compute_complete_name(self):
+        if not self.name:
+            return  # new record
+        channel = self
+        parts = [channel.name]
+        while channel.parent_id:
+            channel = channel.parent_id
+            parts.append(channel.name)
+        self.complete_name = '.'.join(reversed(parts))
+
+    @api.one
+    @api.constrains('parent_id')
+    def parent_required(self):
+        if self.name != 'root' and not self.parent_id:
+            raise exceptions.ValidationError(_('Parent channel required.'))
+
+    @api.multi
+    def write(self, values):
+        for channel in self:
+            if (not self.env.context.get('install_mode') and
+                    channel.name == 'root' and
+                    ('name' in values or 'parent_id' in values)):
+                raise exceptions.Warning(_('Cannot change the root channel'))
+        return super(JobChannel, self).write(values)
+
+    @api.multi
+    def unlink(self):
+        for channel in self:
+            if channel.name == 'root':
+                raise exceptions.Warning(_('Cannot remove the root channel'))
+        return super(JobChannel, self).unlink()
+
+    @api.multi
+    def name_get(self):
+        result = []
+        for record in self:
+            result.append((record.id, record.complete_name))
+        return result
+
+
+class JobFunction(models.Model):
+    _name = 'queue.job.function'
+    _description = 'Job Functions'
+    _log_access = False
+
+    @api.model
+    def _default_channel(self):
+        return self.env.ref('connector.channel_root')
+
+    name = fields.Char(select=True)
+    channel_id = fields.Many2one(comodel_name='queue.job.channel',
+                                 string='Channel',
+                                 required=True,
+                                 default=_default_channel)
+    channel = fields.Char(related='channel_id.complete_name',
+                          store=True,
+                          readonly=True)
+
+    @api.model
+    def _setup_complete(self):
+        super(JobFunction, self)._setup_complete()
+        for func in JOB_REGISTRY:
+            if not is_module_installed(self.pool, get_openerp_module(func)):
+                continue
+            func_name = '%s.%s' % (func.__module__, func.__name__)
+            if not self.search_count([('name', '=', func_name)]):
+                self.create({'name': func_name})

--- a/connector/queue/model_view.xml
+++ b/connector/queue/model_view.xml
@@ -90,6 +90,8 @@
                             <field name="date_started"/>
                             <field name="date_done"/>
                             <field name="worker_id"/>
+                            <field name="job_function_id"/>
+                            <field name="channel"/>
                         </group>
                         <group colspan="4">
                             <div>
@@ -128,6 +130,7 @@
                     <field name="date_created"/>
                     <field name="date_done"/>
                     <field name="uuid"/>
+                    <field name="channel"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
@@ -141,6 +144,8 @@
                     <field name="uuid"/>
                     <field name="name"/>
                     <field name="func_string"/>
+                    <field name="channel"/>
+                    <field name="job_function_id"/>
                     <field name="company_id" groups="base.group_multi_company" widget="selection"/>
                     <filter name="pending" string="Pending"
                         domain="[('state', '=', 'pending')]"/>
@@ -152,6 +157,11 @@
                         domain="[('state', '=', 'done')]"/>
                     <filter name="failed" string="Failed"
                         domain="[('state', '=', 'failed')]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Channel" context="{'group_by': 'channel'}" />
+                        <filter string="Job Function" context="{'group_by': 'job_function_id'}" />
+                        <filter string="State" context="{'group_by': 'state'}" />
+                    </group>
                 </search>
             </field>
         </record>
@@ -203,6 +213,101 @@
             <field name="value" eval="'ir.actions.act_window,' + str(ref('action_requeue_job'))"/>
             <field name="key">action</field>
             <field name="model">queue.job</field>
+        </record>
+
+        <record id="view_queue_job_channel_form" model="ir.ui.view">
+            <field name="name">queue.job.channel.form</field>
+            <field name="model">queue.job.channel</field>
+            <field name="arch" type="xml">
+                <form string="Channels" version="7.0">
+                    <group>
+                        <field name="name" attrs="{'required': [('name', '!=', 'root')], 'readonly': [('name', '=', 'root')]}"/>
+                        <field name="parent_id" attrs="{'required': [('name', '!=', 'root')], 'readonly': [('name', '=', 'root')]}"/>
+                        <field name="complete_name"/>
+                    </group>
+                    <group>
+                      <field name="job_function_ids" widget="many2many_tags"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_queue_job_channel_tree" model="ir.ui.view">
+            <field name="name">queue.job.channel.tree</field>
+            <field name="model">queue.job.channel</field>
+            <field name="arch" type="xml">
+                <tree string="Channels" version="7.0">
+                    <field name="complete_name"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_queue_job_channel_search" model="ir.ui.view">
+            <field name="name">queue.job.channel.search</field>
+            <field name="model">queue.job.channel</field>
+            <field name="arch" type="xml">
+                <search string="Channels">
+                    <field name="name"/>
+                    <field name="complete_name"/>
+                    <field name="parent_id"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_queue_job_channel" model="ir.actions.act_window">
+            <field name="name">Channels</field>
+            <field name="res_model">queue.job.channel</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{}</field>
+            <field name="view_id" ref="view_queue_job_channel_tree"/>
+        </record>
+
+        <record id="view_queue_job_function_form" model="ir.ui.view">
+            <field name="name">queue.job.function.form</field>
+            <field name="model">queue.job.function</field>
+            <field name="arch" type="xml">
+                <form string="Job Functions" create="false" delete="false" version="7.0">
+                    <group>
+                        <field name="name" readonly="1"/>
+                        <field name="channel_id"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="view_queue_job_function_tree" model="ir.ui.view">
+            <field name="name">queue.job.function.tree</field>
+            <field name="model">queue.job.function</field>
+            <field name="arch" type="xml">
+                <tree string="Job Functions" create="false" delete="false" version="7.0">
+                    <field name="name"/>
+                    <field name="channel_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_queue_job_function_search" model="ir.ui.view">
+            <field name="name">queue.job.function.search</field>
+            <field name="model">queue.job.function</field>
+            <field name="arch" type="xml">
+                <search string="Job Functions">
+                    <field name="name"/>
+                    <field name="channel_id"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Channel" context="{'group_by': 'channel_id'}" />
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_queue_job_function" model="ir.actions.act_window">
+            <field name="name">Job Functions</field>
+            <field name="res_model">queue.job.function</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{}</field>
+            <field name="view_id" ref="view_queue_job_function_tree"/>
         </record>
 
     </data>

--- a/connector/queue/queue_data.xml
+++ b/connector/queue/queue_data.xml
@@ -41,4 +41,12 @@
         </record>
 
     </data>
+
+    <data noupdate="0">
+
+        <record model="queue.job.channel" id="channel_root">
+            <field name="name">root</field>
+        </record>
+
+    </data>
 </openerp>

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -350,7 +350,7 @@ def start_service():
 # 2. Or it is used in multiprocess (with option ``--workers``)
 #    but the current process is a Connector Worker
 #    (launched with the ``openerp-connector-worker`` script).
-if not os.environ.get('ODOO_CONNECTOR_RUNNER_ENABLE'):
+if not os.environ.get('ODOO_CONNECTOR_CHANNELS'):
     if (not getattr(openerp, 'multi_process', False) or
             getattr(openerp, 'worker_connector', False)):
         start_service()

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -345,10 +345,12 @@ def start_service():
     watcher.start()
 
 # We have to launch the Jobs Workers only if:
+# 0. The alternative connector runner is not enabled
 # 1. OpenERP is used in standalone mode (monoprocess)
 # 2. Or it is used in multiprocess (with option ``--workers``)
 #    but the current process is a Connector Worker
 #    (launched with the ``openerp-connector-worker`` script).
-if (not getattr(openerp, 'multi_process', False) or
-        getattr(openerp, 'worker_connector', False)):
-    start_service()
+if not os.environ.get('ODOO_CONNECTOR_RUNNER_ENABLE'):
+    if (not getattr(openerp, 'multi_process', False) or
+            getattr(openerp, 'worker_connector', False)):
+        start_service()

--- a/connector/security/ir.model.access.csv
+++ b/connector/security/ir.model.access.csv
@@ -2,3 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_connector_queue_worker_manager,connector worker manager,connector.model_queue_worker,connector.group_connector_manager,1,1,1,1
 access_connector_queue_job_manager,connector job manager,connector.model_queue_job,connector.group_connector_manager,1,1,1,1
 access_connector_checkpoint_manager,connector checkpoint manager,connector.model_connector_checkpoint,connector.group_connector_manager,1,1,1,1
+access_connector_queue_job_function_manager,connector job functions manager,connector.model_queue_job_function,connector.group_connector_manager,1,1,1,1
+access_connector_queue_job_channel_manager,connector job channel manager,connector.model_queue_job_channel,connector.group_connector_manager,1,1,1,1

--- a/connector/session.py
+++ b/connector/session.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 import openerp
 from openerp.modules.registry import RegistryManager
 
+from .connector import is_module_installed
 from .deprecate import log_deprecate
 
 _logger = logging.getLogger(__name__)
@@ -261,4 +262,4 @@ class ConnectorSession(object):
         model with name ``module_name.installed`` is loaded in the
         registry.
         """
-        return bool(self.pool.get('%s.installed' % module_name))
+        return is_module_installed(self.pool, module_name)

--- a/connector/tests/__init__.py
+++ b/connector/tests/__init__.py
@@ -29,3 +29,5 @@ from . import test_producer
 from . import test_connector
 from . import test_mapper
 from . import test_related_action
+from . import test_runner_channels
+from . import test_runner_runner

--- a/connector/tests/test_runner_channels.py
+++ b/connector/tests/test_runner_channels.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import doctest
+from openerp.addons.connector.jobrunner import channels
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(channels))
+    return tests

--- a/connector/tests/test_runner_runner.py
+++ b/connector/tests/test_runner_runner.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import doctest
+from openerp.addons.connector.jobrunner import runner
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(runner))
+    return tests


### PR DESCRIPTION
This is an alternative to connector workers that 
- avoids polling, 
- is easier to deploy, 
- implements job channels (a variation on #43).

For more information on how to use it, see the docstring in runner.py.
For more information on job channels, see the docstring of the Channel class in channels.py.

It is safe to try in real deployments because it is fully compatible and it is easy to switch between the new runner and workers.

TODO:
- [x] can we run the doctests from travis/runbot?
- [x] there is a couple of todo left in the code, but nothing preventing real life usage according to me
