### PR TITLE
Calculate eta on job to max(eta)+POSTPONE_INTERVAL

### DIFF
--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -51,6 +51,7 @@ STATES = [(PENDING, 'Pending'),
 DEFAULT_PRIORITY = 10  # used by the PriorityQueue to sort the jobs
 DEFAULT_MAX_RETRIES = 5
 RETRY_INTERVAL = 10 * 60  # seconds
+POSTPONE_INTERVAL = 3 * 60  # seconds between postpones
 
 _logger = logging.getLogger(__name__)
 
@@ -599,13 +600,32 @@ class Job(object):
         result = msg if msg is not None else _('Canceled. Nothing to do.')
         self.set_done(result=result)
 
-    def postpone(self, result=None, seconds=None):
+    def postpone(self, result=None, session=None, seconds=None):
         """ Write an estimated time arrival to n seconds
         later than now. Used when an retryable exception
         want to retry a job later. """
-        if seconds is None:
-            seconds = RETRY_INTERVAL
-        self.eta = timedelta(seconds=seconds)
+        job_model = session.pool.get('queue.job')
+        job_ids = job_model.search(session.cr,
+                                   session.uid,
+                                   [('eta', '!=', False), ('state', 'not in', ['done', 'failed'])],
+                                   order='eta desc', limit=1,
+                                   context=session.context)
+
+        if job_ids:
+            reads = job_model.read(session.cr,
+                                   session.uid,
+                                   job_ids[0],
+                                   ['uuid', 'eta', 'state'],
+                                   context=session.context)
+
+            self.eta = datetime.strptime(reads['eta'],
+                                         DEFAULT_SERVER_DATETIME_FORMAT) + \
+                                         timedelta(seconds=POSTPONE_INTERVAL)
+        else:
+            if seconds is None:
+                seconds = RETRY_INTERVAL
+            self.eta = timedelta(seconds=seconds)
+
         self.exc_info = None
         if result is not None:
             self.result = result

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -71,7 +71,7 @@ class Worker(threading.Thread):
         """ Execute a job """
         def retry_postpone(job, message, seconds=None):
             with session_hdl.session() as session:
-                job.postpone(result=message, seconds=seconds)
+                job.postpone(result=message, session=session, seconds=seconds)
                 job.set_enqueued(self)
                 self.job_storage_class(session).store(job)
             self.queue.enqueue(job)


### PR DESCRIPTION
Made modification to enqueue Jobs calculating max eta. So when jobs are postponed (for example, when _Sales Order_ hasn't been **paid**) they will be enqueued with same _interval_ between them.

Maybe it is not a good implementation, but it was done because when there are too much _Sales Order_ to import, and they are _postponed, __Magento__ receives too much _requests_. With this modification, requests are always performed with **POSTPONED_INTERVAL** between them.

I think this interval should be configured from _User Interface_, but first I need somebody review this **PR** to know if this feature is worth.

Excuse my bad English.
