### PR TITLE
Don't confuse Nose with a function which is not a test

### DIFF
--- a/connector/tests/test_related_action.py
+++ b/connector/tests/test_related_action.py
@@ -43,7 +43,7 @@ def task_wikipedia(session, subject):
 
 
 @related_action(action=unwrap_binding)
-def test_unwrap_binding(session, model_name, binding_id):
+def try_unwrap_binding(session, model_name, binding_id):
     pass
 
 
@@ -94,7 +94,7 @@ class test_related_action(unittest2.TestCase):
             def unwrap_model(self):
                 return 'res.users'
 
-        job = Job(func=test_unwrap_binding, args=('res.users', 555))
+        job = Job(func=try_unwrap_binding, args=('res.users', 555))
         session = mock.MagicMock(name='session')
         backend_record = mock.Mock(name='backend_record')
         backend = mock.Mock(name='backend')
@@ -128,7 +128,7 @@ class test_related_action(unittest2.TestCase):
             def unwrap_model(self):
                 raise ValueError('Not an inherits')
 
-        job = Job(func=test_unwrap_binding, args=('res.users', 555))
+        job = Job(func=try_unwrap_binding, args=('res.users', 555))
         session = mock.MagicMock(name='session')
         backend_record = mock.Mock(name='backend_record')
         backend = mock.Mock(name='backend')
@@ -175,7 +175,7 @@ class test_related_action_storage(common.TransactionCase):
 
     def test_unwrap_binding_not_exists(self):
         """ Call the related action on the model on non-existing record """
-        job = Job(func=test_unwrap_binding, args=('res.users', 555))
+        job = Job(func=try_unwrap_binding, args=('res.users', 555))
         storage = OpenERPJobStorage(self.session)
         storage.store(job)
         stored_job = self.queue_job.search([('uuid', '=', job.uuid)])


### PR DESCRIPTION
Hi,

I just added some builders on our buildbot and I got an error with Nose : 
http://buildbot.anybox.fr/builders/connector-postgresql-9.2/builds/1/steps/tests/logs/stdio

```
======================================================================
ERROR: connector.tests.test_related_action.test_unwrap_binding
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/buildslave/buildbot.anybox.fr/buildout-caches/eggs/nose-1.3.6-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
TypeError: test_unwrap_binding() takes exactly 3 arguments (0 given)

----------------------------------------------------------------------
```

What I understand is that `test_unwrap_binding` is not a real test but a function definition used in the test `test_related_action.test_unwrap_binding`. Am I wrong?

After renaming the function it's ok:
http://buildbot.anybox.fr/builders/connector-postgresql-9.2/builds/3/steps/tests/logs/stdio
