### PR TITLE
Automatically build and push docs to GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ virtualenv:
   system_site_packages: true
 
 env:
+  matrix:
   - VERSION="8.0" LINT_CHECK="1"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
   - VERSION="8.0" DOCS="1" LINT_CHECK="0"
+  global:
+    secure: imkzmLXFYCB/2leIMiujghWwkw2TNTnXRYayDI9qlyR6pYXHx5lvEljfpTpvEDYywjfSLrkDya51APrUs8aLbAANDgkL/l17uFfD5ObmwLWYg+pwRmD+JhryCR0B6bP684RzXgFsyJ2zlLgTrCUvPMT6MIgUEwVnXXSgwB6lOC0=
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
@@ -27,3 +30,4 @@ script:
 
 after_success:
   - if [ -z "$DOCS" ] ; then coveralls; fi
+  - if [ -n "$DOCS" ] ; then ./.travis_push_doc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: python
 
 python:
-  - "2.7"
+  - '2.7'
 
 virtualenv:
   system_site_packages: true
@@ -11,14 +11,19 @@ env:
   - VERSION="8.0" LINT_CHECK="1"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+  - VERSION="8.0" DOCS="1" LINT_CHECK="0"
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
 
+services:
+  - postgresql
+
 script:
-  - travis_run_tests
+  - if [ -z "$DOCS" ] ; then travis_run_tests; fi
+  - if [ -n "$DOCS" ] ; then ./.travis_build_doc; fi
 
 after_success:
-  coveralls
+  - if [ -z "$DOCS" ] ; then coveralls; fi

--- a/.travis_build_doc
+++ b/.travis_build_doc
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cd ${HOME}
+mkdir buildout && cd buildout
+ln -s ${TRAVIS_BUILD_DIR} connector
+ln -s ${HOME}/odoo-${VERSION} odoo
+cat <<EOF > buildout.cfg
+[buildout]
+parts = openerp
+versions = versions
+find-links = http://download.gna.org/pychart/
+
+[openerp]
+recipe = anybox.recipe.odoo:server
+version = local odoo
+addons = local connector
+
+eggs = sphinx
+       sphinx_bootstrap_theme
+       sphinx-intl
+
+openerp_scripts = sphinx-build=sphinx-build command-line-options=-d
+                  sphinx-apidoc=sphinx-apidoc command-line-options=-d
+                  sphinx-intl=sphinx-intl command-line-options=-d
+
+[versions]
+EOF
+wget https://bootstrap.pypa.io/bootstrap-buildout.py -O bootstrap.py
+python bootstrap.py && bin/buildout
+createdb connectordb
+bin/start_openerp -d connectordb --stop-after-init
+cd connector/connector/doc/
+${HOME}/buildout/bin/sphinx-build -d connectordb -- -b html ./ ${HOME}/doc

--- a/.travis_push_doc
+++ b/.travis_push_doc
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ $TRAVIS_BRANCH = "8.0" ] && [ $TRAVIS_PULL_REQUEST = false ]; then
+  cd ${TRAVIS_BUILD_DIR}
+  rev=$(git rev-parse --short HEAD)
+
+  cd ${HOME}/doc
+  git init
+  git config user.name "Guewen Baconnier"
+  git config user.email "guewen.baconnier@camptocamp.com"
+  git remote add upstream https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+  git fetch upstream
+  git reset upstream/gh-pages
+
+  echo "odoo-connector.com" > CNAME
+  touch .nojekyll
+
+  touch .
+  git add -A .
+  git commit -m"rebuild pages at ${rev}"
+
+  git push -q upstream HEAD:gh-pages
+fi


### PR DESCRIPTION
Use Travis to build the sphinx documentation at each new commit.

Once build, the doc is available at http://oca.github.io/connector
The goal being to redirect the domain odoo-connector.com on this URL once this PR is merged.

The docs are built in the `script` part, so if it fails, the build is considered failed.
The docs are then pushed in `after_success` so if it fails, the build remain green. It is only pushed when the branch is `8.0`.

As an example, you can see the result on my fork:
- the builds: https://travis-ci.org/guewen/connector/builds
- the gh-pages branch: https://github.com/guewen/connector/tree/gh-pages
- the served pages: http://guewen.github.io/connector/
