### PR TITLE
Allow to build a ConnectorSession directly from an Odoo Environment

### DIFF
--- a/connector/session.py
+++ b/connector/session.py
@@ -117,6 +117,11 @@ class ConnectorSession(object):
             context = {}
         self.env = openerp.api.Environment(cr, uid, context)
 
+    @classmethod
+    def from_env(cls, env):
+        """ Return a ConnectorSession from :class:`openerp.api.Environment` """
+        return cls(env.cr, env.uid, context=env.context)
+
     @property
     def cr(self):
         return self.env.cr

--- a/connector/tests/test_session.py
+++ b/connector/tests/test_session.py
@@ -74,6 +74,14 @@ class test_connector_session(common.TransactionCase):
         self.assertEqual(session.context, session.env.context)
         self.assertEqual(session.pool, session.env.registry)
 
+    def test_from_env(self):
+        """ ConnectorSession.from_env(env) """
+        session = ConnectorSession.from_env(self.env)
+        self.assertEqual(session.cr, self.env.cr)
+        self.assertEqual(session.uid, self.env.uid)
+        self.assertEqual(session.context, self.env.context)
+        self.assertEqual(session.pool, self.env.registry)
+
     def test_change_user(self):
         """
         Change the user and check if it is reverted correctly at the end


### PR DESCRIPTION
Replace the verbose: ConnectorSession(self.env.cr, self.env.uid, context=self.env.context)
By: ConnectorSession.from_env(self.env)
