### PR TITLE
Allow to assign a default channel on @job functions

### DIFF
--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -589,8 +589,14 @@ class Job(object):
 JOB_REGISTRY = set()
 
 
-def job(func):
+def job(func=None, default_channel='root'):
     """ Decorator for jobs.
+
+    Optional argument:
+
+    :param default_channel: the channel wherein the job will be assigned. This
+                            channel is set at the installation of the module
+                            and can be manually changed later using the views.
 
    Add a ``delay`` attribute on the decorated function.
 
@@ -646,10 +652,18 @@ def job(func):
         # => the job will be executed with a low priority and not before a
         # delay of 5 hours from now
 
+        @job(default_channel='root.subchannel')
+        def export_one_thing(session, model_name, one_thing):
+            # work
+            # export one_thing
+
     See also: :py:func:`related_action` a related action can be attached
     to a job
 
     """
+    if func is None:
+        return functools.partial(job, default_channel=default_channel)
+
     def delay(session, model_name, *args, **kwargs):
         """Enqueue the function. Return the uuid of the created job."""
         return OpenERPJobStorage(session).enqueue_resolve_args(
@@ -657,8 +671,12 @@ def job(func):
             model_name=model_name,
             *args,
             **kwargs)
-    JOB_REGISTRY.add(func)
+
+    assert default_channel == 'root' or default_channel.startswith('root.'), (
+        "The channel path must start by 'root'")
+    func.default_channel = default_channel
     func.delay = delay
+    JOB_REGISTRY.add(func)
     return func
 
 

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -674,3 +674,19 @@ class TestJobChannels(common.TransactionCase):
         storage.store(test_job)
         stored = self.job_model.search([('uuid', '=', test_job.uuid)])
         self.assertEquals(stored.channel, 'root.sub')
+
+    def test_default_channel(self):
+        self.function_model.search([]).unlink()
+        job(task_a, default_channel='root.sub.subsub')
+        self.assertEquals(task_a.default_channel, 'root.sub.subsub')
+
+        self.function_model._register_jobs()
+
+        path_a = 'openerp.addons.connector.tests.test_job.task_a'
+        job_func = self.function_model.search([('name', '=', path_a)])
+
+        self.assertEquals(job_func.channel, 'root.sub.subsub')
+        channel = job_func.channel_id
+        self.assertEquals(channel.name, 'subsub')
+        self.assertEquals(channel.parent_id.name, 'sub')
+        self.assertEquals(channel.parent_id.parent_id.name, 'root')


### PR DESCRIPTION
When the @job is registered and created in the database, it lookups its
channel and creates it if it don't exist yet.

Allows to do:

``` python

@job(default_channel='root.channel.subchannel')
def a_task(session, arg):
    pass

```

Also add tests on jobs and channels models
