### PR TITLE
8.0 smart export

### DIFF
--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -476,6 +476,30 @@ class test_mapper(unittest2.TestCase):
         self.assertEqual(options['undefined'], None)
         self.assertEqual(options.undefined, None)
 
+    def test_changed_by_fields(self):
+        """ Test attribute ``_changed_by_fields`` on Mapper."""
+        class MyExportMapper(ExportMapper):
+
+            direct = [('street', 'out_street'),
+                      (none('in_t'), 'out_t'),
+                      (none(convert('in_f', bool)), 'out_f')]
+
+            @changed_by('name', 'city')
+            @mapping
+            def name(self):
+                pass
+
+            @changed_by('email')
+            @mapping
+            def email(self):
+                pass
+
+            def no_decorator(self):
+                pass
+
+        self.assertEqual(MyExportMapper._changed_by_fields,
+                         set(['street', 'in_t', 'in_f', 'name', 'city', 'email']))
+
 
 class test_mapper_binding(common.TransactionCase):
     """ Test Mapper with Bindings"""

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -497,8 +497,9 @@ class test_mapper(unittest2.TestCase):
             def no_decorator(self):
                 pass
 
-        self.assertEqual(MyExportMapper._changed_by_fields,
-                         set(['street', 'in_t', 'in_f', 'name', 'city', 'email']))
+        self.assertEqual(
+            MyExportMapper._changed_by_fields,
+            set(['street', 'in_t', 'in_f', 'name', 'city', 'email']))
 
 
 class test_mapper_binding(common.TransactionCase):

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -302,7 +302,7 @@ class MetaMapper(MetaConnectorUnit):
         changed_by_fields = set()
         if attrs.get('direct'):
             for from_attr, __ in attrs['direct']:
-                attr_name = cls._mapping_field_name(from_attr)
+                attr_name = cls._direct_source_field_name(from_attr)
                 changed_by_fields.add(attr_name)
         for method_name, method_def in attrs['_map_methods'].iteritems():
             changed_by_fields |= method_def[0]
@@ -313,7 +313,7 @@ class MetaMapper(MetaConnectorUnit):
         super(MetaMapper, cls).__init__(name, bases, attrs)
 
     @staticmethod
-    def _mapping_field_name(mapping_attr):
+    def _direct_source_field_name(mapping_attr):
         """ Get the mapping field name. Goes through the function modifiers.
 
         Ex: [(none(convert(field_name, str)), out_field_name)]
@@ -326,7 +326,7 @@ class MetaMapper(MetaConnectorUnit):
                 # type object (ex 'bool', 'str') are callable but doesn't have
                 # attribute 'func_closure'
                 if callable(contents) and type(contents) != type:
-                    attr_name = MetaMapper._mapping_field_name(contents)
+                    attr_name = MetaMapper._direct_source_field_name(contents)
                 else:
                     attr_name = contents
         return attr_name
@@ -712,7 +712,7 @@ class Mapper(ConnectorUnit):
                 # function. BUT the argument order seems to be not enforced
                 # by python in the closure so we use the first non callable
                 # cell_contents in the closure as attr_name
-                attr_name = MetaMapper._mapping_field_name(from_attr)
+                attr_name = MetaMapper._direct_source_field_name(from_attr)
             else:
                 attr_name = from_attr
 

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -307,7 +307,6 @@ class MetaMapper(MetaConnectorUnit):
             if hasattr(base, 'exported_fields') and base.exported_fields:
                 exported_fields += base.exported_fields
         cls.exported_fields = list(set(exported_fields))
-        print name, cls.exported_fields
         super(MetaMapper, cls).__init__(name, bases, attrs)
 
 

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -303,6 +303,7 @@ class MetaMapper(MetaConnectorUnit):
         if attrs.get('direct'):
             for from_attr, to_attr in attrs['direct']:
                 attr_name = from_attr
+                # Support if the direct mapping has a function modifier
                 if callable(from_attr):
                     for cell in from_attr.func_closure:
                         contents = cell.cell_contents

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -299,8 +299,14 @@ class MetaMapper(MetaConnectorUnit):
         """
         exported_fields = []
         if attrs.get('direct'):
-            for field_tuple in attrs['direct']:
-                exported_fields.append(field_tuple[0])
+            for from_attr, to_attr in attrs['direct']:
+                attr_name = from_attr
+                if callable(from_attr):
+                    for cell in from_attr.func_closure:
+                        contents = cell.cell_contents
+                        if not callable(contents):
+                            attr_name = contents
+                exported_fields.append(attr_name)
         for method_name, method_def in attrs['_map_methods'].iteritems():
             exported_fields += list(method_def[0])
         for base in bases:

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -295,9 +295,11 @@ class MetaMapper(MetaConnectorUnit):
 
     def __init__(cls, name, bases, attrs):
         """
-        Build a ``exported_fields`` list of synchronized fields with mapper.
+        Build a ``changed_by_fields`` list of synchronized fields with mapper.
+        It takes in account the ``direct`` fields and the fields declared in
+        the decorator : ``changed_by``.
         """
-        exported_fields = []
+        changed_by_fields = []
         if attrs.get('direct'):
             for from_attr, to_attr in attrs['direct']:
                 attr_name = from_attr
@@ -306,13 +308,13 @@ class MetaMapper(MetaConnectorUnit):
                         contents = cell.cell_contents
                         if not callable(contents):
                             attr_name = contents
-                exported_fields.append(attr_name)
+                changed_by_fields.append(attr_name)
         for method_name, method_def in attrs['_map_methods'].iteritems():
-            exported_fields += list(method_def[0])
+            changed_by_fields += list(method_def[0])
         for base in bases:
-            if hasattr(base, 'exported_fields') and base.exported_fields:
-                exported_fields += base.exported_fields
-        cls.exported_fields = list(set(exported_fields))
+            if hasattr(base, 'changed_by_fields') and base.changed_by_fields:
+                changed_by_fields += base.changed_by_fields
+        cls.changed_by_fields = list(set(changed_by_fields))
         super(MetaMapper, cls).__init__(name, bases, attrs)
 
 

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -299,23 +299,23 @@ class MetaMapper(MetaConnectorUnit):
         It takes in account the ``direct`` fields and the fields declared in
         the decorator : ``changed_by``.
         """
-        changed_by_fields = set([])
+        changed_by_fields = set()
         if attrs.get('direct'):
-            for from_attr, to_attr in attrs['direct']:
+            for from_attr, __ in attrs['direct']:
                 attr_name = cls._mapping_field_name(from_attr)
                 changed_by_fields.add(attr_name)
         for method_name, method_def in attrs['_map_methods'].iteritems():
-            changed_by_fields = changed_by_fields.union(method_def[0])
+            changed_by_fields |= method_def[0]
         for base in bases:
             if hasattr(base, '_changed_by_fields') and base._changed_by_fields:
-                changed_by_fields = changed_by_fields.union(base._changed_by_fields)
+                changed_by_fields |= base._changed_by_fields
         cls._changed_by_fields = changed_by_fields
         super(MetaMapper, cls).__init__(name, bases, attrs)
 
     @staticmethod
     def _mapping_field_name(mapping_attr):
-        """
-        Get the mapping field name. Goes through the function modifiers.
+        """ Get the mapping field name. Goes through the function modifiers.
+
         Ex: [(none(convert(field_name, str)), out_field_name)]
         """
         attr_name = mapping_attr

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -239,7 +239,6 @@ def backend_to_m2o(field, binding=None, with_inactive=False):
     return modifier
 
 
-
 MappingDefinition = namedtuple('MappingDefinition',
                                ['changed_by',
                                 'only_create'])

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -327,7 +327,7 @@ class MetaMapper(MetaConnectorUnit):
                 # type object (ex 'bool', 'str') are callable but doesn't have
                 # attribute 'func_closure'
                 if callable(contents) and type(contents) != type:
-                    attr_name = _mapping_field_name(contents)
+                    attr_name = MetaMapper._mapping_field_name(contents)
                 else:
                     attr_name = contents
         return attr_name

--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -293,6 +293,23 @@ class MetaMapper(MetaConnectorUnit):
                 cls._map_methods[attr_name] = definition
         return cls
 
+    def __init__(cls, name, bases, attrs):
+        """
+        Build a ``exported_fields`` list of synchronized fields with mapper.
+        """
+        exported_fields = []
+        if attrs.get('direct'):
+            for field_tuple in attrs['direct']:
+                exported_fields.append(field_tuple[0])
+        for method_name, method_def in attrs['_map_methods'].iteritems():
+            exported_fields += list(method_def[0])
+        for base in bases:
+            if hasattr(base, 'exported_fields') and base.exported_fields:
+                exported_fields += base.exported_fields
+        cls.exported_fields = list(set(exported_fields))
+        print name, cls.exported_fields
+        super(MetaMapper, cls).__init__(name, bases, attrs)
+
 
 class MapChild(ConnectorUnit):
     """ MapChild is responsible to convert items.


### PR DESCRIPTION
This PR adds the attribute changed_by_fields on the Mapper classes.

This attribute can be used in the consumer that creates the job to check if the modified fields are meant to be exported or not.

It can be useful to avoid a useless export job.
