### PR TITLE
Option --load=web,connector no longer required

### DIFF
--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -25,7 +25,6 @@
 
 import logging
 import os
-from threading import Thread
 import time
 
 from openerp.tools import config

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -56,7 +56,7 @@ How to use it?
   - ODOO_CONNECTOR_CHANNELS=root:4 (or any other channels configuration)
   - optional if xmlrpc_port is not set: ODOO_CONNECTOR_PORT=8069
 
-* Start Odoo with --load=web,connector and --workers > 1. [2]
+* Start Odoo with --workers > 1. [2]
 * Disable then "Enqueue Jobs" cron.
 * Do NOT start openerp-connector-worker.
 * Create jobs (eg using base_import_async) and observe they


### PR DESCRIPTION
If the module contains a folder named 'static', the controller will be loaded.
So it is no longer necessary to load it with the --load option
