### PR TITLE
7.0 - manage retryable job with runner

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -51,7 +51,7 @@ class RunJobController(http.Controller):
         def retry_postpone(job, message, seconds=None):
             with session_hdl.session() as session:
                 job.postpone(result=message, seconds=seconds)
-                job.set_pending(self)
+                job.set_pending(self, reset_retry=False)
                 self.job_storage_class(session).store(job)
 
         with session_hdl.session() as session:

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -559,12 +559,13 @@ class Job(object):
                              " it must be an 'int', a 'timedelta' "
                              "or a 'datetime'" % type(value))
 
-    def set_pending(self, result=None):
+    def set_pending(self, result=None, reset_retry=True):
         self.state = PENDING
         self.date_enqueued = None
         self.date_started = None
         self.worker_uuid = None
-        self.retry = 0
+        if reset_retry:
+            self.retry = 0
         if result is not None:
             self.result = result
 


### PR DESCRIPTION
With runner,

When a retryablejoberror is raised, the retry job is not incremented.
It is reset to zero when set_pending is called, in consequence job retry indefinitely.

Any advices or examples to test controller is welcome !
