### PR TITLE
Add an index on queue_job.worker_id

### DIFF
--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -77,7 +77,8 @@ class QueueJob(orm.Model):
 
     _columns = {
         'worker_id': fields.many2one('queue.worker', string='Worker',
-                                     ondelete='set null', readonly=True),
+                                     ondelete='set null', readonly=True,
+                                     select=True),
         'uuid': fields.char('UUID', readonly=True, select=True, required=True),
         'user_id': fields.many2one('res.users', string='User ID',
                                    required=True),


### PR DESCRIPTION
This column appears often in the where clauses with the old workers.
