### PR TITLE
Add an index on queue_job.worker_id

### DIFF
--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -48,6 +48,7 @@ class QueueJob(models.Model):
     worker_id = fields.Many2one(comodel_name='queue.worker',
                                 string='Worker',
                                 ondelete='set null',
+                                select=True,
                                 readonly=True)
     uuid = fields.Char(string='UUID',
                        readonly=True,


### PR DESCRIPTION
This column appears often in the where clauses with the old workers.
