### PR TITLE
Move fields to avoid jobs view overflows

### DIFF
--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -89,6 +89,7 @@ class QueueJob(models.Model):
     func_name = fields.Char(readonly=True)
     job_function_id = fields.Many2one(comodel_name='queue.job.function',
                                       compute='_compute_channel',
+                                      string='Job Function',
                                       readonly=True,
                                       store=True)
     # for searching without JOIN on channels

--- a/connector/queue/model_view.xml
+++ b/connector/queue/model_view.xml
@@ -81,18 +81,16 @@
                         <group>
                             <field name="uuid"/>
                             <field name="func_string"/>
+                            <field name="job_function_id"/>
+                            <field name="channel"/>
+                            <field name="worker_id"/>
                         </group>
-                        <group col="6">
+                        <group>
                             <group>
                                 <field name="priority"/>
                                 <field name="eta"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="user_id"/>
-                            </group>
-                            <group>
-                                <field name="worker_id"/>
-                                <field name="job_function_id"/>
-                                <field name="channel"/>
                             </group>
                             <group>
                                 <field name="date_created"/>


### PR DESCRIPTION
The job function, channel and worker fields are too large for a 6 column
layout. Job function and channel make the fields overflow of the form and the
worker fields is wrapped over 3 lines

Example of overflow due to the job function

![2015-07-23-130328_1687x488_scrot](https://cloud.githubusercontent.com/assets/417223/8849397/99bd62c6-313f-11e5-9904-d509df826172.png)

Due to the channel

![2015-07-23-132630_1685x500_scrot](https://cloud.githubusercontent.com/assets/417223/8849411/af881bf0-313f-11e5-9e5a-492dde1867e7.png)

Wrap of the worker

![2015-07-23-132833_1684x529_scrot](https://cloud.githubusercontent.com/assets/417223/8849418/bf6087d8-313f-11e5-96bb-72aa1b3eeda3.png)

Result of this pull request

![2015-07-23-133330_1684x554_scrot](https://cloud.githubusercontent.com/assets/417223/8849431/e0668018-313f-11e5-8881-764d53e05017.png)
