### PR TITLE
[7.0] Do not pass self as 'message' of set_pending()

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -51,7 +51,7 @@ class RunJobController(http.Controller):
         def retry_postpone(job, message, seconds=None):
             with session_hdl.session() as session:
                 job.postpone(result=message, seconds=seconds)
-                job.set_pending(self, reset_retry=False)
+                job.set_pending(reset_retry=False)
                 self.job_storage_class(session).store(job)
 
         with session_hdl.session() as session:


### PR DESCRIPTION
Fixes #96
