### PR TITLE
connector : dynamic channel by company

### DIFF
--- a/connector/queue/model_view.xml
+++ b/connector/queue/model_view.xml
@@ -224,6 +224,7 @@
                         <field name="name" attrs="{'required': [('name', '!=', 'root')], 'readonly': [('name', '=', 'root')]}"/>
                         <field name="parent_id" attrs="{'required': [('name', '!=', 'root')], 'readonly': [('name', '=', 'root')]}"/>
                         <field name="complete_name"/>
+                        <field name="channel_by_company" groups="base.group_multi_company"/>
                     </group>
                     <group>
                       <field name="job_function_ids" widget="many2many_tags"/>


### PR DESCRIPTION
On channel add "channel_by_company" flag to execute job in different channel in function of the company of the job

Use case :
Delivery Order (DO) are transfered by a job.
If many DO contains same product, the transfer failed.
For the moment, these job are retryable, but in some case (many DO) it is not sufficient.
So, we want use a channel with a capacity of 1.
But it is multi-company environment, so we want parallelize transfer of different companies.
