### PR TITLE
Allow to define seconds and ignore retries when raising RetryableJobError

### DIFF
--- a/connector/CHANGES.rst
+++ b/connector/CHANGES.rst
@@ -5,6 +5,7 @@ Future (?)
 ~~~~~~~~~~
 
 * Allow to define seconds when raising a RetryableJobError (https://github.com/OCA/connector/pull/124)
+* Allow to ignore the retry counter when raising a RetryableJobError (https://github.com/OCA/connector/pull/124)
 
 3.2.0 (2015-09-10)
 ~~~~~~~~~~~~~~~~~~

--- a/connector/CHANGES.rst
+++ b/connector/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Future (?)
+~~~~~~~~~~
+
+* Allow to define seconds when raising a RetryableJobError (https://github.com/OCA/connector/pull/124)
+
 3.2.0 (2015-09-10)
 ~~~~~~~~~~~~~~~~~~
 

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -94,7 +94,7 @@ class RunJobController(http.Controller):
 
         except RetryableJobError as err:
             # delay the job later, requeue
-            retry_postpone(job, unicode(err))
+            retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
 
         except OperationalError as err:

--- a/connector/exception.py
+++ b/connector/exception.py
@@ -59,11 +59,14 @@ class RetryableJobError(JobError):
     If seconds is empty, it will be retried according to the ``retry_pattern``
     of the job or by :const:`connector.queue.job.RETRY_INTERVAL` if nothing
     is defined.
+
+    If ``ignore_retry`` is True, the retry counter will not be increased.
     """
 
-    def __init__(self, msg, seconds=None):
+    def __init__(self, msg, seconds=None, ignore_retry=False):
         super(RetryableJobError, self).__init__(msg)
         self.seconds = seconds
+        self.ignore_retry = ignore_retry
 
 
 class NetworkRetryableError(RetryableJobError):

--- a/connector/exception.py
+++ b/connector/exception.py
@@ -53,7 +53,17 @@ class FailedJobError(JobError):
 
 
 class RetryableJobError(JobError):
-    """ A job had an error but can be retried. """
+    """ A job had an error but can be retried.
+
+    The job will be retried after the given number of seconds.
+    If seconds is empty, it will be retried according to the ``retry_pattern``
+    of the job or by :const:`connector.queue.job.RETRY_INTERVAL` if nothing
+    is defined.
+    """
+
+    def __init__(self, msg, seconds=None):
+        super(RetryableJobError, self).__init__(msg)
+        self.seconds = seconds
 
 
 class NetworkRetryableError(RetryableJobError):

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -465,8 +465,11 @@ class Job(object):
             self.retry += 1
             try:
                 self.result = self.func(session, *self.args, **self.kwargs)
-            except RetryableJobError:
-                if not self.max_retries:  # infinite retries
+            except RetryableJobError as err:
+                if err.ignore_retry:
+                    self.retry -= 1
+                    raise
+                elif not self.max_retries:  # infinite retries
                     raise
                 elif self.retry >= self.max_retries:
                     type_, value, traceback = sys.exc_info()

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -694,7 +694,7 @@ def job(func=None, default_channel='root', retry_pattern=None):
             # retries 5 to 10 postponed 20 minutes later
             # retries 10 to 15 postponed 30 minutes later
             # all subsequent retries postponed 12 hours later
-            raise RetryableJobError
+            raise RetryableJobError('Must be retried later')
 
         retryable_example.delay(session)
 

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -137,7 +137,7 @@ class Worker(threading.Thread):
 
         except RetryableJobError as err:
             # delay the job later, requeue
-            retry_postpone(job, unicode(err))
+            retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
 
         except OperationalError as err:

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -48,7 +48,7 @@ def dummy_task_args(session, model_name, a, b, c=None):
 
 
 def retryable_error_task(session):
-    raise RetryableJobError
+    raise RetryableJobError('Must be retried later')
 
 
 class TestJobs(unittest2.TestCase):


### PR DESCRIPTION
The job will be retried after the given number of seconds if the exception is
raised with a defined 'seconds' argument.
