### PR TITLE
Clear environment caches and recomputations upon failures

### DIFF
--- a/connector/session.py
+++ b/connector/session.py
@@ -77,9 +77,10 @@ class ConnectorSessionHandler(object):
                                        context=self.context)
 
             try:
-                RegistryManager.check_registry_signaling(self.db_name)
-                yield session
-                RegistryManager.signal_caches_change(self.db_name)
+                with session.env.clear_upon_failure():
+                    RegistryManager.check_registry_signaling(self.db_name)
+                    yield session
+                    RegistryManager.signal_caches_change(self.db_name)
             except:
                 session.rollback()
                 raise


### PR DESCRIPTION
Two fixes here for v8.0: 
### Recompute fields before closing the cursor

**Current behaviour**
When there are fields to be recomputed inside the job function and that the latter crashes with a retryable OperationalError, nothing happens. The job remains marked 'started' and blocks the channel. On the log, we can see a `Unable to use closed cursor` exception after the OperationalError of the job.

**Expected behaviour**
The job should be set to pending according thanks to `rety_postpone()` function, and free the channel.

**Explanation of the problem**
If the job fails on a transaction where there are fields to recompute (in `Environments.todo`) then 
these fields will never be recomputed because the cursor will be closed and this will lead to a "Unable to use close cursor exception on the next write operation (since write triggers the recomputation of fields). 

Since the next write operation is the postponing of the job in `retry_postpone()`, the job remains marked as 'started' whereas it is actually crashed. 

**Proposed solution**
The proposed solution is to clear the recompute `Environments.todo` list when an exception occurs.
