### PR TITLE
Context manager to acquire Postgres advisory locks

### DIFF
--- a/connector/tests/test_connector.py
+++ b/connector/tests/test_connector.py
@@ -3,11 +3,29 @@
 import mock
 import unittest2
 
+from openerp import api
+from openerp.modules.registry import RegistryManager
 from openerp.tests import common
 from openerp.addons.connector import connector
-from openerp.addons.connector.connector import (ConnectorUnit,
-                                                ConnectorEnvironment)
+from openerp.addons.connector.exception import RetryableJobError
+from openerp.addons.connector.connector import (
+    ConnectorEnvironment,
+    ConnectorUnit,
+    pg_try_advisory_lock,
+)
 from openerp.addons.connector.session import ConnectorSession
+
+
+def mock_connector_unit(env):
+    session = ConnectorSession(env.cr, env.uid,
+                               context=env.context)
+    backend_record = mock.Mock(name='BackendRecord')
+    backend = mock.Mock(name='Backend')
+    backend_record.get_backend.return_value = backend
+    connector_env = connector.ConnectorEnvironment(backend_record,
+                                                   session,
+                                                   'res.users')
+    return ConnectorUnit(connector_env)
 
 
 class ConnectorHelpers(unittest2.TestCase):
@@ -122,15 +140,7 @@ class TestConnectorUnitTransaction(common.TransactionCase):
         class ModelUnit(ConnectorUnit):
             _model_name = 'res.users'
 
-        session = ConnectorSession(self.env.cr, self.env.uid,
-                                   context=self.env.context)
-        backend_record = mock.Mock(name='BackendRecord')
-        backend = mock.Mock(name='Backend')
-        backend_record.get_backend.return_value = backend
-        connector_env = connector.ConnectorEnvironment(backend_record,
-                                                       session,
-                                                       'res.users')
-        unit = ConnectorUnit(connector_env)
+        unit = mock_connector_unit(self.env)
         self.assertEqual(unit.model, self.env['res.users'])
         self.assertEqual(unit.env, self.env)
         self.assertEqual(unit.localcontext, self.env.context)
@@ -177,3 +187,48 @@ class TestConnectorEnvironment(unittest2.TestCase):
 
         self.assertEqual(type(new_env), MyConnectorEnvironment)
         self.assertEqual(new_env.api, api)
+
+
+class TestAdvisoryLock(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAdvisoryLock, self).setUp()
+        self.registry2 = RegistryManager.get(common.get_db_name())
+        self.cr2 = self.registry2.cursor()
+        self.env2 = api.Environment(self.cr2, self.env.uid, {})
+
+        @self.addCleanup
+        def reset_cr2():
+            # rollback and close the cursor, and reset the environments
+            self.env2.reset()
+            self.cr2.rollback()
+            self.cr2.close()
+
+    def test_concurrent_lock(self):
+        """ 2 concurrent transactions cannot acquire the same lock """
+        lock = 'import_record({}, {}, {}, {})'.format(
+            'backend.name',
+            1,
+            'res.partner',
+            '999999',
+        )
+        acquired = pg_try_advisory_lock(self.env, lock)
+        self.assertTrue(acquired)
+        inner_acquired = pg_try_advisory_lock(self.env2, lock)
+        self.assertFalse(inner_acquired)
+
+    def test_concurrent_import_lock(self):
+        """ A 2nd concurrent transaction must retry """
+        lock = 'import_record({}, {}, {}, {})'.format(
+            'backend.name',
+            1,
+            'res.partner',
+            '999999',
+        )
+        connector_unit = mock_connector_unit(self.env)
+        with connector_unit.try_advisory_lock(lock):
+            connector_unit2 = mock_connector_unit(self.env2)
+            with self.assertRaises(RetryableJobError) as cm:
+                with connector_unit2.try_advisory_lock(lock, retry_seconds=3):
+                    pass
+            self.assertEquals(cm.exception.seconds, 3)


### PR DESCRIPTION
This Postgres feature is invaluable when dealing with synchronisations,
especially when importing concurrently records from a system.

When we export a record, we are able to acquire a lock on the exported record
to prevent 2 jobs to export it at the same time. This is different when we
import a record for the first time and with several jobs running in parallel,
chances are high that 2 jobs will import the same record at the same moment.

The Postgres advisory lock comes handy there for they allow to acquire an
application lock.  Usually we'll acquire the lock at the beginning of an import
(beginning of `Importer.run()`) and we'll throw a `RetryableJobError` if
the lock cannot be acquired so the job is retried later. The lock will remain
in place until the end of the transaction.

Example:
- Job 1 imports Partner A
- Job 2 imports Partner B
- Partner A has a category X which happens not to exist yet
- Partner B has a category X which happens not to exist yet
- Job 1 import category X as a dependency
- Job 2 import category X as a dependency

Since both jobs are executed concurrently, they both create a record for category X.
With this lock:
- Job 1 imports Partner A, it puts a lock for this partner
- Job 2 imports Partner B, it puts a lock for this partner
- Partner A has a category X which happens not to exist yet
- Partner B has a category X which happens not to exist yet
- Job 1 import category X as a dependency, it puts a lock for this category
- Job 2 import category X as a dependency, try to put a lock but can't, Job 2
  is retried later, and when it is retried, it sees the category X created by
  Job 1

See http://topopps.com/implementing-postgres-advisory-locks/ for the article
where I learned about the computation of the hash for this purpose.
