### PR TITLE
Rename try_advisory_lock to advisory_lock_or_retry

### DIFF
--- a/connector/tests/test_connector.py
+++ b/connector/tests/test_connector.py
@@ -226,9 +226,8 @@ class TestAdvisoryLock(common.TransactionCase):
             '999999',
         )
         connector_unit = mock_connector_unit(self.env)
-        with connector_unit.try_advisory_lock(lock):
-            connector_unit2 = mock_connector_unit(self.env2)
-            with self.assertRaises(RetryableJobError) as cm:
-                with connector_unit2.try_advisory_lock(lock, retry_seconds=3):
-                    pass
+        connector_unit.advisory_lock_or_retry(lock)
+        connector_unit2 = mock_connector_unit(self.env2)
+        with self.assertRaises(RetryableJobError) as cm:
+            connector_unit2.advisory_lock_or_retry(lock, retry_seconds=3)
             self.assertEquals(cm.exception.seconds, 3)


### PR DESCRIPTION
It is no longer a context manager, because we would expect the lock to be
released at the end of the 'with' statement but it lasts until the end of the
transaction.
