### PR TITLE
Fix bug introduced in c97ebbd in jobrunner

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -135,7 +135,7 @@ def _async_http_get(port, db_name, job_uuid):
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
-        conn = psycopg2.connect(openerp.sql_db.dsn(db_name))
+        conn = psycopg2.connect(openerp.sql_db.dsn(db_name)[0])
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with closing(conn.cursor()) as cr:
             cr.execute(


### PR DESCRIPTION
Commit c97ebbd was a frontport from 7.0.
However, openerp.sql_db.dsn was changed in 8.0 in that it now returns a
tuple. Extract the db_name from the returned tuple.
