### PR TITLE
Fix the fix c3fefd2 :-(

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -135,7 +135,7 @@ def _async_http_get(port, db_name, job_uuid):
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
-        conn = psycopg2.connect(openerp.sql_db.dsn(db_name)[0])
+        conn = psycopg2.connect(openerp.sql_db.dsn(db_name)[1])
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with closing(conn.cursor()) as cr:
             cr.execute(


### PR DESCRIPTION
The first item contains the name of the DB such as 'odoo_db' and the
second item contains 'user=gbaconnier dbname=odoo_db' which is what
expects psycopg2.connect.

I feel stupid about my first correction especially since I was sure to have
correctly tested it (automated test is hard here). At least, it does not
prevent jobs to run.
