### PR TITLE
[FIX] ignore dbfilter, fixes #58

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -112,7 +112,6 @@ Caveat
 from contextlib import closing
 import logging
 import os
-import re
 import select
 import threading
 import time
@@ -265,9 +264,6 @@ class ConnectorRunner(object):
             db_names = openerp.tools.config['db_name'].split(',')
         else:
             db_names = openerp.service.db.exp_list(True)
-        dbfilter = openerp.tools.config['dbfilter']
-        if dbfilter and '%d' not in dbfilter and '%h' not in dbfilter:
-            db_names = [d for d in db_names if re.match(dbfilter, d)]
         return db_names
 
     def close_databases(self, remove_jobs=True):

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -19,7 +19,6 @@
 #
 ##############################################################################
 
-import re
 import logging
 import os
 import threading
@@ -261,9 +260,6 @@ class WorkerWatcher(threading.Thread):
             db_names = config['db_name'].split(',')
         else:
             db_names = db.exp_list(True)
-        dbfilter = config['dbfilter']
-        if dbfilter and '%d' not in dbfilter and '%h' not in dbfilter:
-            db_names = [d for d in db_names if re.match(dbfilter, d)]
         available_db_names = []
         for db_name in db_names:
             session_hdl = ConnectorSessionHandler(db_name,


### PR DESCRIPTION
dbfilter can contains %d or %h, referring to the client hostname.
Since connector does run independently of client, it can not rely
on the dbfilter concept.
