### PR TITLE
[FIX] ignore dbfilter containing %d or %h, fixes #58

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -266,7 +266,7 @@ class ConnectorRunner(object):
         else:
             db_names = openerp.service.db.exp_list()
         dbfilter = openerp.tools.config['dbfilter']
-        if dbfilter:
+        if dbfilter and '%d' not in dbfilter and '%h' not in dbfilter:
             db_names = [d for d in db_names if re.match(dbfilter, d)]
         return db_names
 

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -262,7 +262,7 @@ class WorkerWatcher(threading.Thread):
         else:
             db_names = db.exp_list(True)
         dbfilter = config['dbfilter']
-        if dbfilter and db_names:
+        if dbfilter and '%d' not in dbfilter and '%h' not in dbfilter:
             db_names = [d for d in db_names if re.match(dbfilter, d)]
         available_db_names = []
         for db_name in db_names:


### PR DESCRIPTION
This is a temporary fix. In version 4.0, dbfilter should be completely ignored by connector.
