### PR TITLE
Manage non-ascii PG errors

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -94,7 +94,8 @@ class RunJobController(http.Controller):
                 if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
                     raise
 
-                retry_postpone(job, unicode(err), seconds=PG_RETRY)
+                retry_postpone(job, unicode(err.pgerror, errors='replace'), 
+                               seconds=PG_RETRY)
                 _logger.debug('%s OperationalError, postponed', job)
 
         except NothingToDoJob as err:

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -5,7 +5,7 @@ from cStringIO import StringIO
 from psycopg2 import OperationalError
 
 import openerp
-from openerp import http
+from openerp import http, tools
 from openerp.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 from ..session import ConnectorSessionHandler
@@ -94,7 +94,7 @@ class RunJobController(http.Controller):
                 if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
                     raise
 
-                retry_postpone(job, unicode(err.pgerror, errors='replace'),
+                retry_postpone(job, tools.ustr(err.pgerror, errors='replace'),
                                seconds=PG_RETRY)
                 _logger.debug('%s OperationalError, postponed', job)
 

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -94,7 +94,7 @@ class RunJobController(http.Controller):
                 if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
                     raise
 
-                retry_postpone(job, unicode(err.pgerror, errors='replace'), 
+                retry_postpone(job, unicode(err.pgerror, errors='replace'),
                                seconds=PG_RETRY)
                 _logger.debug('%s OperationalError, postponed', job)
 


### PR DESCRIPTION
When PG is localized, error messages are not ascii and jobs are not postponed. Instead they are failed with a 'unicode decode error'.

Note: even if PG `lc_messages` is set to en_us.utf8 on a localized system, the error message prefixes (such as `DETAILS:`) are still localized.
