### PR TITLE
[8.0] Prevent to unpickle globals which are not jobs

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -233,10 +233,11 @@ class Database(object):
             cr.execute("LISTEN connector")
 
     def select_jobs(self, where, args):
-        query = "SELECT %s, uuid, id as seq, date_created, priority, eta, state " \
-                "FROM queue_job WHERE %s" % \
-                ('channel' if self.has_channel else 'NULL',
-                 where)
+        query = ("SELECT %s, uuid, id as seq, date_created, "
+                 "priority, eta, state "
+                 "FROM queue_job WHERE %s" %
+                 ('channel' if self.has_channel else 'NULL',
+                  where))
         with closing(self.conn.cursor()) as cr:
             cr.execute(query, args)
             return list(cr.fetchall())


### PR DESCRIPTION
This is a safeguard to prevent someone to write arbitrary code in jobs.
Builtin types and datetime/timedelta are allowed in job arguments, and a
new function 'whitelist_unpickle_global' allows to register new objects
if needed.

I will do a proper release with a new addon's version and updated changelog in
a PR after this one is merged.

This change may bring backward incompatibilities issues, precisely errors if you pickle a type/function which is not allowed by the custom unpickler. If this happens to you, you'd want to add in your addon module:

``` python
from openerp.addons.connector.queue.job import whitelist_unpickle_global

whitelist_unpickle_global(your_object_to_allow)
```

/cc @lmignon @sbidoul @gurneyalex @colinnewell
