### PR TITLE
Add job_uuid in context

### DIFF
--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -507,7 +507,8 @@ class Job(object):
         with session.change_user(self.user_id):
             self.retry += 1
             try:
-                self.result = self.func(session, *self.args, **self.kwargs)
+                with session.change_context({'job_uuid': self._uuid}):
+                    self.result = self.func(session, *self.args, **self.kwargs)
             except RetryableJobError as err:
                 if err.ignore_retry:
                     self.retry -= 1

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -49,7 +49,6 @@ def dummy_task_args(session, model_name, a, b, c=None):
 
 
 def dummy_task_context(session):
-    _logger.info("\n\n{0}\n\n".format(session.env.context))
     return session.env.context
 
 

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -48,6 +48,11 @@ def dummy_task_args(session, model_name, a, b, c=None):
     return a + b + c
 
 
+def dummy_task_context(session):
+    _logger.info("\n\n{0}\n\n".format(session.env.context))
+    return session.env.context
+
+
 def retryable_error_task(session):
     raise RetryableJobError('Must be retried later')
 
@@ -590,6 +595,13 @@ class TestJobModel(common.TransactionCase):
         model.create({}).requeue()
         self.assertEqual(stored.state, PENDING)
         self.assertFalse(stored.worker_id)
+
+    def test_context_uuid(self):
+        test_job = Job(func=dummy_task_context)
+        result = test_job.perform(self.session)
+        key_present = 'job_uuid' in result
+        self.assertTrue(key_present)
+        self.assertEqual(result['job_uuid'], test_job._uuid)
 
 
 class TestJobStorageMultiCompany(common.TransactionCase):


### PR DESCRIPTION
Hello,

This PR add the job_uuid in the context of the function being executed. This allow to easily retrieve information which may be needed by the subfunction and relative to the job, like the date when the execution started, the job id in itself etc...

Context : We absolutely need it for the Clouder project, because the log of system calls are stored in the job itself. Currently we have no way to retrieve the job which called the function.
