### PR TITLE
[REF] write function - more modularity

### DIFF
--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -148,8 +148,11 @@ class QueueJob(models.Model):
         return True
 
     @api.multi
-    def write(self, vals):
-        res = super(QueueJob, self).write(vals)
+    def pre_write(self):
+        pass
+
+    @api.multi
+    def post_write(self, vals):
         if vals.get('state') == 'failed':
             # subscribe the users now to avoid to subscribe them
             # at every job creation
@@ -159,6 +162,12 @@ class QueueJob(models.Model):
                 if msg:
                     job.message_post(body=msg,
                                      subtype='connector.mt_job_failed')
+
+    @api.multi
+    def write(self, vals):
+        self.pre_write()
+        res = super(QueueJob, self).write(vals)
+        self.post_write(vals)
         return res
 
     @api.multi


### PR DESCRIPTION
Small refactoring of the write method in queue/model.py

I found my self in the necessity to write a module that silenced some error notifications that were bothering the client. I could not do a clean inheritance the way write() is structured now. I am proposing a refactoring to allow the write function to accept more future modularity.

Ideally to avoid the situation I found myself in we should have:

``` python
def write(self):
    self.pre_write()
    res=SUPER
    self.post_write()
    return res   



```
