### PR TITLE
Managing InvalidDataError

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -129,7 +129,6 @@ class RunJobController(http.Controller):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())
-
             job.set_failed(exc_info=buff.getvalue())
             with session_hdl.session() as session:
                 self.job_storage_class(session).store(job)


### PR DESCRIPTION
PR to manage explicitly InvalidDataErrors.

When importing products from the magento backend. It used to get stuck when trying to import a product in of a currently non supported type (example downloadable or bundle).
I am running with jobrunner.

The job would remain stuck at "Started" because the generic exception would be called , and all database writes would be rolled back.

I am submitting a PR that manages explicitly in main.py the case of data type error, catches it , does the same thing the generic does  (sets to fail) but does not raise errors.

It solved my problem, hopefully it is broadly useful.
