### PR TITLE
8.0 manage invalid data error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Available addons
 ----------------
 addon | version | summary
 --- | --- | ---
-[connector](connector/) | 8.0.3.2.0 | Connector
+[connector](connector/) | 8.0.3.3.0 | Connector
 [connector_base_product](connector_base_product/) | 8.0.1.0.0 | Connector Base Product
 
 [//]: # (end addons)

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -15,8 +15,7 @@ from ..exception import (NoSuchJobError,
                          NotReadableJobError,
                          RetryableJobError,
                          FailedJobError,
-                         NothingToDoJob,
-                         InvalidDataError)
+                         NothingToDoJob)
 
 _logger = logging.getLogger(__name__)
 
@@ -112,7 +111,8 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        except (FailedJobError, InvalidDataError, Exception):
+
+        except:
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -129,7 +129,6 @@ class RunJobController(http.Controller):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())
-
             job.set_failed(exc_info=buff.getvalue())
             with session_hdl.session() as session:
                 self.job_storage_class(session).store(job)

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -15,7 +15,8 @@ from ..exception import (NoSuchJobError,
                          NotReadableJobError,
                          RetryableJobError,
                          FailedJobError,
-                         NothingToDoJob)
+                         NothingToDoJob,
+                         InvalidDataError)
 
 _logger = logging.getLogger(__name__)
 
@@ -111,21 +112,7 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        """
-        Manage Invalid data error in order not to 
-        raise and rollback DB job failed transaction.
-        Explicitly managing InvalidDataError
-        """
-        except InvalidDataError as err:
-            buff = StringIO()
-            traceback.print_exc(file=buff)
-            _logger.error(buff.getvalue())
-
-            job.set_failed(exc_info=buff.getvalue())
-            with session_hdl.session() as session:
-                self.job_storage_class(session).store(job)
-        
-        except (FailedJobError, Exception):
+        except (FailedJobError, InvaliDataError, Exception):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -112,7 +112,7 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        except (FailedJobError, InvaliDataError, Exception):
+        except (FailedJobError, InvalidDataError, Exception):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())

--- a/connector/i18n/ca.po
+++ b/connector/i18n/ca.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2015-10-15 13:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/oca/OCA-connector-8-0/language/ca/)\n"
@@ -92,7 +92,7 @@ msgid "Cancel"
 msgstr "Cancel·la"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Cancel·lat, res a fer."

--- a/connector/i18n/de.po
+++ b/connector/i18n/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-04 08:58+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2016-01-14 12:58+0000\n"
 "Last-Translator: Rudolf Schnapka <rs@techno-flex.de>\n"
 "Language-Team: German (http://www.transifex.com/oca/OCA-connector-8-0/language/de/)\n"
@@ -92,7 +92,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Storniert. Nicht zu tun."

--- a/connector/i18n/en.po
+++ b/connector/i18n/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2015-10-15 13:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: English (http://www.transifex.com/oca/OCA-connector-8-0/language/en/)\n"
@@ -90,7 +90,7 @@ msgid "Cancel"
 msgstr "Cancel"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Canceled. Nothing to do."

--- a/connector/i18n/fr.po
+++ b/connector/i18n/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2015-10-15 13:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: French (http://www.transifex.com/oca/OCA-connector-8-0/language/fr/)\n"
@@ -92,7 +92,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Annulé. Rien à faire."

--- a/connector/i18n/pt_BR.po
+++ b/connector/i18n/pt_BR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2015-10-15 13:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_BR/)\n"
@@ -92,7 +92,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Cancelado. Nada a se fazer"

--- a/connector/i18n/sl.po
+++ b/connector/i18n/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
+"POT-Creation-Date: 2016-03-01 01:37+0000\n"
 "PO-Revision-Date: 2015-10-15 13:38+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/oca/OCA-connector-8-0/language/sl/)\n"
@@ -91,7 +91,7 @@ msgid "Cancel"
 msgstr "Preklic"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:617
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr "Preklicano. Ni opravkov."

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -507,7 +507,8 @@ class Job(object):
         with session.change_user(self.user_id):
             self.retry += 1
             try:
-                self.result = self.func(session, *self.args, **self.kwargs)
+                with session.change_context({'job_uuid': self._uuid}):
+                    self.result = self.func(session, *self.args, **self.kwargs)
             except RetryableJobError as err:
                 if err.ignore_retry:
                     self.retry -= 1

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -49,7 +49,6 @@ def dummy_task_args(session, model_name, a, b, c=None):
 
 
 def dummy_task_context(session):
-    _logger.info("\n\n{0}\n\n".format(session.env.context))
     return session.env.context
 
 

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -48,6 +48,11 @@ def dummy_task_args(session, model_name, a, b, c=None):
     return a + b + c
 
 
+def dummy_task_context(session):
+    _logger.info("\n\n{0}\n\n".format(session.env.context))
+    return session.env.context
+
+
 def retryable_error_task(session):
     raise RetryableJobError('Must be retried later')
 
@@ -590,6 +595,13 @@ class TestJobModel(common.TransactionCase):
         model.create({}).requeue()
         self.assertEqual(stored.state, PENDING)
         self.assertFalse(stored.worker_id)
+
+    def test_context_uuid(self):
+        test_job = Job(func=dummy_task_context)
+        result = test_job.perform(self.session)
+        key_present = 'job_uuid' in result
+        self.assertTrue(key_present)
+        self.assertEqual(result['job_uuid'], test_job._uuid)
 
 
 class TestJobStorageMultiCompany(common.TransactionCase):


### PR DESCRIPTION
Problem:
I would have many jobs stuck in start.  THese jobs Had all raised InvalidDataError.
Strangely the Exception was not catched in main.py, but the generic 

Therefore the store function that had to write my failed job would never trigger

When explicitly importing InvalidDataError, the exception was catched (see commit  
https://github.com/gfcapalbo/connector/commit/5b77f3c6d77a9e10ee3f0f2e2fca72747e0f0244)

I replaced except (FailedJobError, InvaliDataError, Exception):  
with 
except:

I am still not sure why this works for me, but it seems OK to set ALL of the forseeable exceptions to fail jobs.
