### PR TITLE
8.0 manage invalid data error

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -15,8 +15,7 @@ from ..exception import (NoSuchJobError,
                          NotReadableJobError,
                          RetryableJobError,
                          FailedJobError,
-                         NothingToDoJob,
-                         InvalidDataError)
+                         NothingToDoJob)
 
 _logger = logging.getLogger(__name__)
 
@@ -112,7 +111,8 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        except (FailedJobError, InvalidDataError, Exception):
+
+        except:
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -129,7 +129,6 @@ class RunJobController(http.Controller):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())
-
             job.set_failed(exc_info=buff.getvalue())
             with session_hdl.session() as session:
                 self.job_storage_class(session).store(job)

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -15,7 +15,8 @@ from ..exception import (NoSuchJobError,
                          NotReadableJobError,
                          RetryableJobError,
                          FailedJobError,
-                         NothingToDoJob)
+                         NothingToDoJob,
+                         InvalidDataError)
 
 _logger = logging.getLogger(__name__)
 
@@ -111,21 +112,7 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        """
-        Manage Invalid data error in order not to 
-        raise and rollback DB job failed transaction.
-        Explicitly managing InvalidDataError
-        """
-        except InvalidDataError as err:
-            buff = StringIO()
-            traceback.print_exc(file=buff)
-            _logger.error(buff.getvalue())
-
-            job.set_failed(exc_info=buff.getvalue())
-            with session_hdl.session() as session:
-                self.job_storage_class(session).store(job)
-        
-        except (FailedJobError, Exception):
+        except (FailedJobError, InvaliDataError, Exception):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -112,7 +112,7 @@ class RunJobController(http.Controller):
             # delay the job later, requeue
             retry_postpone(job, unicode(err), seconds=err.seconds)
             _logger.debug('%s postponed', job)
-        except (FailedJobError, InvaliDataError, Exception):
+        except (FailedJobError, InvalidDataError, Exception):
             buff = StringIO()
             traceback.print_exc(file=buff)
             _logger.error(buff.getvalue())


### PR DESCRIPTION
Problem:
I would have many jobs stuck in start. THese jobs Had all raised InvalidDataError.
Strangely the Exception was not catched in main.py, but the generic

Therefore the store function that had to write my failed job would never trigger

When explicitly importing InvalidDataError, the exception was catched (see commit

gfcapalbo@5b77f3c)

I replaced except (FailedJobError, InvaliDataError, Exception):

with
except:

I am still not sure why this works for me, but it seems OK to set ALL of the forseeable exceptions to fail jobs.
