### PR TITLE
Move connector settings menu to technical

### DIFF
--- a/connector/__openerp__.py
+++ b/connector/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 {'name': 'Connector',
- 'version': '9.0.1.0.2',
+ 'version': '9.0.1.0.3',
  'author': 'Camptocamp,Openerp Connector Core Editors,'
            'Odoo Community Association (OCA)',
  'website': 'http://odoo-connector.com',

--- a/connector/setting_view.xml
+++ b/connector/setting_view.xml
@@ -40,7 +40,7 @@
             <field name="target">inline</field>
         </record>
 
-        <menuitem id="menu_connector_config_settings" name="Connector" parent="base.menu_config"
+        <menuitem id="menu_connector_config_settings" name="Connector" parent="base.menu_custom"
             sequence="20" action="action_connector_config_settings"/>
 
     </data>


### PR DESCRIPTION
This PR moves the Connector settings menu to the Technical Settings submenu. 

Odoo 9 made the General Settings menu a link, which current implementation breaks by adding itself as a submenu.
