### PR TITLE
Fix backend_to_m2o to extract id of the binding

### DIFF
--- a/connector/CHANGES.rst
+++ b/connector/CHANGES.rst
@@ -6,6 +6,12 @@ Changelog
 .. 
 .. * 
 
+Future (?)
+~~~~~~~~~~
+
+* Fix backend_to_m2o to extract id of the binding (https://github.com/OCA/connector/pull/194)
+
+
 9.0.1.0.2 (2016-03-03)
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -18,6 +24,7 @@ Changelog
 * Removed the old workers
 * Removed the broken dbfilter support (https://github.com/OCA/connector/issues/58)
 * Cleaned the methods that have been deprecated in version 3.x
+
 
 8.0.3.3.0 (2016-02-29)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -570,10 +570,11 @@ class test_mapper_binding(common.TransactionCase):
             direct = [(backend_to_m2o('country'), 'country_id')]
 
         record = {'country': 10}
-        self.country_binder.to_openerp.return_value = 44
+        ch = self.env.ref('base.ch')
+        self.country_binder.to_openerp.return_value = ch
         mapper = MyMapper(self.connector_env)
         map_record = mapper.map_record(record)
-        self.assertEqual(map_record.values(), {'country_id': 44})
+        self.assertEqual(map_record.values(), {'country_id': ch.id})
         self.country_binder.to_openerp.assert_called_once_with(
             10, unwrap=False)
 


### PR DESCRIPTION
The default binder returns a recordset of one record since 41561c8 so
backend_to_m2o should extract the Id from it.

Port from https://github.com/OCA/connector/pull/153
