### PR TITLE
Remove cancellation of jobs and their active flag

### DIFF
--- a/connector/CHANGES.rst
+++ b/connector/CHANGES.rst
@@ -10,7 +10,8 @@ Future (?)
 ~~~~~~~~~~
 
 * Fix backend_to_m2o to extract id of the binding (https://github.com/OCA/connector/pull/194)
-
+* Remove cancellation of jobs / active flag on jobs, now jobs are only set to
+  Done when NothingToDoJob is raised.
 
 9.0.1.0.2 (2016-03-03)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -5,7 +5,7 @@ from cStringIO import StringIO
 from psycopg2 import OperationalError
 
 import openerp
-from openerp import http, tools
+from openerp import _, http, tools
 from openerp.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 from ..session import ConnectorSessionHandler
@@ -102,8 +102,8 @@ class RunJobController(http.Controller):
             if unicode(err):
                 msg = unicode(err)
             else:
-                msg = None
-            job.cancel(msg)
+                msg = _('Job interrupted and set to Done: nothing to do.')
+            job.set_done(msg)
             with session_hdl.session() as session:
                 self.job_storage_class(session).store(job)
 

--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -29,7 +29,6 @@ from cPickle import dumps, UnpicklingError, Unpickler
 from cStringIO import StringIO
 
 import openerp
-from openerp.tools.translate import _
 
 from ..exception import (NotReadableJobError,
                          NoSuchJobError,
@@ -186,7 +185,7 @@ class OpenERPJobStorage(JobStorage):
         return bool(self.db_record_from_uuid(job_uuid))
 
     def db_record_from_uuid(self, job_uuid):
-        model = self.job_model.sudo().with_context(active_test=False)
+        model = self.job_model.sudo()
         record = model.search([('uuid', '=', job_uuid)], limit=1)
         if record:
             return record.with_env(self.job_model.env)
@@ -220,9 +219,6 @@ class OpenERPJobStorage(JobStorage):
             vals['date_done'] = dt_to_string(job_.date_done)
         if job_.eta:
             vals['eta'] = dt_to_string(job_.eta)
-
-        if job_.canceled:
-            vals['active'] = False
 
         db_record = self.db_record(job_)
         if db_record:
@@ -279,7 +275,6 @@ class OpenERPJobStorage(JobStorage):
         job_.result = stored.result if stored.result else None
         job_.exc_info = stored.exc_info if stored.exc_info else None
         job_.user_id = stored.user_id.id if stored.user_id else None
-        job_.canceled = not stored.active
         job_.model_name = stored.model_name if stored.model_name else None
         job_.retry = stored.retry
         job_.max_retries = stored.max_retries
@@ -376,10 +371,6 @@ class Job(object):
         Estimated Time of Arrival of the job. It will not be executed
         before this date/time.
 
-    .. attribute:: canceled
-
-        True if the job has been canceled.
-
     """
 
     def __init__(self, func=None, model_name=None,
@@ -463,7 +454,6 @@ class Job(object):
         self.company_id = None
         self._eta = None
         self.eta = eta
-        self.canceled = False
 
     def __cmp__(self, other):
         if not isinstance(other, Job):
@@ -482,7 +472,6 @@ class Job(object):
         :param session: session to execute the job
         :type session: ConnectorSession
         """
-        assert not self.canceled, "Canceled job"
         with session.change_user(self.user_id):
             self.retry += 1
             try:
@@ -587,11 +576,6 @@ class Job(object):
 
     def __repr__(self):
         return '<Job %s, priority:%d>' % (self.uuid, self.priority)
-
-    def cancel(self, msg=None):
-        self.canceled = True
-        result = msg if msg is not None else _('Canceled. Nothing to do.')
-        self.set_done(result=result)
 
     def _get_retry_seconds(self, seconds=None):
         retry_pattern = self.func.retry_pattern

--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -69,7 +69,6 @@ class QueueJob(models.Model):
     date_enqueued = fields.Datetime(string='Enqueue Time', readonly=True)
     date_done = fields.Datetime(string='Date Done', readonly=True)
     eta = fields.Datetime(string='Execute only after')
-    active = fields.Boolean(default=True)
     model_name = fields.Char(string='Model', readonly=True)
     retry = fields.Integer(string='Current try')
     max_retries = fields.Integer(
@@ -188,13 +187,12 @@ class QueueJob(models.Model):
 
     @api.model
     def autovacuum(self):
-        """ Delete all jobs (active or not) done since more than
-        ``_removal_interval`` days.
+        """ Delete all jobs done since more than ``_removal_interval`` days.
 
         Called from a cron.
         """
         deadline = datetime.now() - timedelta(days=self._removal_interval)
-        jobs = self.with_context(active_test=False).search(
+        jobs = self.search(
             [('date_done', '<=', fields.Datetime.to_string(deadline))],
         )
         jobs.unlink()

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -292,13 +292,6 @@ class TestJobs(unittest.TestCase):
         self.assertEquals(job_a.state, FAILED)
         self.assertEquals(job_a.exc_info, 'failed test')
 
-    def test_cancel(self):
-        job_a = Job(func=task_a)
-        job_a.cancel(msg='test')
-        self.assertTrue(job_a.canceled)
-        self.assertEquals(job_a.state, DONE)
-        self.assertEquals(job_a.result, 'test')
-
     def test_postpone(self):
         job_a = Job(func=task_a)
         datetime_path = 'openerp.addons.connector.queue.job.datetime'
@@ -406,7 +399,6 @@ class TestJobStorage(common.TransactionCase):
         job_read.date_enqueued = test_date
         job_read.date_started = test_date
         job_read.date_done = test_date
-        job_read.canceled = True
         storage.store(job_read)
 
         job_read = storage.load(test_job.uuid)
@@ -416,7 +408,6 @@ class TestJobStorage(common.TransactionCase):
                                delta=delta)
         self.assertAlmostEqual(job_read.date_done, test_date,
                                delta=delta)
-        self.assertEqual(job_read.canceled, True)
 
     def test_job_unlinked(self):
         test_job = Job(func=dummy_task_args,
@@ -558,9 +549,7 @@ class TestJobModel(common.TransactionCase):
 
     def test_autovacuum(self):
         stored = self._create_job()
-        stored2 = self._create_job()
         stored.write({'date_done': '2000-01-01 00:00:00'})
-        stored2.write({'date_done': '2000-01-01 00:00:00', 'active': False})
         self.env['queue.job'].autovacuum()
         self.assertEqual(len(self.env['queue.job'].search([])), 0)
 


### PR DESCRIPTION
Now jobs are only set to Done when NothingToDoJob is raised.

Closes #197
