### PR TITLE
Fix wrong recordset returned when no binding found

### DIFF
--- a/connector/connector.py
+++ b/connector/connector.py
@@ -370,6 +370,8 @@ class Binder(ConnectorUnit):
              (self._backend_field, '=', self.backend_record.id)]
         )
         if not bindings:
+            if unwrap:
+                return getattr(self.model.browse(), self._openerp_field)
             return self.model.browse()
         bindings.ensure_one()
         if unwrap:


### PR DESCRIPTION
When we call the binder 'to_openerp' method with 'unwrap', we expect the
binder to return the 'unwrapped' record of the binding, e.g.
product.product instead of prestashop.product.product.

When no record is found, the binder _must_ return an empty recordset of
the correct (unwrapped) model too.
