### PR TITLE
[9.0][FIX] connector: Zero value assertion

### DIFF
--- a/connector/connector.py
+++ b/connector/connector.py
@@ -416,7 +416,7 @@ class Binder(ConnectorUnit):
         :type binding_id: int
         """
         # Prevent False, None, or "", but not 0
-        assert (external_id or external_id == 0) and binding_id, (
+        assert (external_id or external_id is 0) and binding_id, (
             "external_id or binding_id missing, "
             "got: %s, %s" % (external_id, binding_id)
         )


### PR DESCRIPTION
- Switch zero assertion to type strict eval (`is`)

Before:

```
>>> external_id = False
>>> binding_id = True
>>> assert (external_id or external_id == 0) and binding_id
# No assertion raised
```

After

``` python
>>> external_id = 'test'
>>> assert (external_id or external_id is 0) and binding_id
>>> external_id = 0
>>> assert (external_id or external_id is 0) and binding_id
>>> external_id = False
>>> assert (external_id or external_id is 0) and binding_id
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> external_id = None
>>> assert (external_id or external_id is 0) and binding_id
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```

Taken from my fix in OCA/connector-magento#220 - not sure why the code is duplicated ¯_(ツ)_/¯
