### PR TITLE
[FIX] Prevent MissingError to be raised due to dangling recomputations

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -80,6 +80,11 @@ class RunJobController(http.Controller):
                 job.set_pending(reset_retry=False)
                 self.job_storage_class(session).store(job)
 
+        def clear_env(env):
+            """ Clear any dangling recomputations from failed job """
+            env.clear_recompute_old()
+            env.all.todo.clear()
+
         with session_hdl.session() as session:
             job = self._load_job(session, job_uuid)
             if job is None:
@@ -105,6 +110,7 @@ class RunJobController(http.Controller):
                 msg = None
             job.cancel(msg)
             with session_hdl.session() as session:
+                clear_env(session.env)
                 self.job_storage_class(session).store(job)
 
         except RetryableJobError as err:
@@ -119,6 +125,7 @@ class RunJobController(http.Controller):
 
             job.set_failed(exc_info=buff.getvalue())
             with session_hdl.session() as session:
+                clear_env(session.env)
                 self.job_storage_class(session).store(job)
             raise
 


### PR DESCRIPTION
Fixes jobs getting stuck in 'started' state after an exception was raised during the execution of a job in which a record was created.
