### PR TITLE
Fix some tests

### DIFF
--- a/connector/connector.py
+++ b/connector/connector.py
@@ -449,10 +449,10 @@ class Binder(ConnectorUnit):
         else:
             binding = self.model.browse(binding_id)
 
-        openerp_record = getattr(binding, self._openerp_field)
+        record = getattr(binding, self._openerp_field)
         if browse:
-            return openerp_record
-        return openerp_record.id
+            return record
+        return record.id
 
     def unwrap_model(self):
         """ For a binding model, gives the normal model.

--- a/connector/tests/__init__.py
+++ b/connector/tests/__init__.py
@@ -30,3 +30,4 @@ from . import test_related_action
 from . import test_runner_channels
 from . import test_runner_runner
 from . import test_checkpoint
+from . import test_default_binder

--- a/connector/tests/test_default_binder.py
+++ b/connector/tests/test_default_binder.py
@@ -37,19 +37,28 @@ class TestDefaultBinder(TransactionCase):
         partner.write({'color': 1})
         # bind the main partner to external id = 0
         self.partner_binder.bind(0, partner.id)
+
         # find the openerp partner bound to external partner 0
-        openerp_id = self.partner_binder.to_openerp(0)
-        self.assertEqual(openerp_id, partner.id)
-        openerp_id = self.partner_binder.to_openerp(0)
-        self.assertEqual(openerp_id.id, partner.id)
-        openerp_id = self.partner_binder.to_openerp(0, unwrap=True)
-        self.assertEqual(openerp_id, partner.id)
+        binding = self.partner_binder.to_openerp(0)
+        self.assertEqual(binding.id, partner.id)
+        binding_id = self.partner_binder.to_openerp(0, unwrap=True)
+        self.assertEqual(binding_id, partner.id)
+
+        # we have `_external_field = 'ref'`
+        partner.ref = 'foo'
         # find the external partner bound to openerp partner 1
-        external_id = self.partner_binder.to_backend(partner.id)
-        self.assertEqual(external_id, '0')
-        external_id = self.partner_binder.to_backend(partner.id, wrap=True)
-        self.assertEqual(external_id, '0')
+        backend_id = self.partner_binder.to_backend(partner.id)
+        self.assertEqual(backend_id, 'foo')
+        backend_id = self.partner_binder.to_backend(binding_id, wrap=True)
+        self.assertEqual(backend_id, 'foo')
+
         # unwrap model should be None since we set 'id' as the _openerp_field
         self.assertEqual(self.partner_binder.unwrap_model(), None)
-        # unwrapping the binding should give the same binding
-        self.assertEqual(self.partner_binder.unwrap_binding(1), 1)
+        # unwrapping the binding should give the same binding.
+        self.assertEqual(self.partner_binder.unwrap_binding(1, browse=True), 1)
+        # Yes, we are supposed to have a browser record back BUT
+        # we are faking the binder to play without any real binding model
+        # (see that we have `_openerp_field = 'id'`)
+        # To test all this stuff properly we should have custom test models,
+        # but on Odoo you need to create a separate module for that
+        # and move the tests there.

--- a/connector/tests/test_job.py
+++ b/connector/tests/test_job.py
@@ -728,10 +728,19 @@ class TestJobChannels(common.TransactionCase):
         job(task_a)
         job(task_b)
         self.function_model._register_jobs()
-        path_a = 'openerp.addons.connector.tests.test_job.task_a'
-        path_b = 'openerp.addons.connector.tests.test_job.task_b'
-        self.assertTrue(self.function_model.search([('name', '=', path_a)]))
-        self.assertTrue(self.function_model.search([('name', '=', path_b)]))
+        path_a = 'connector.tests.test_job.task_a'
+        path_b = 'connector.tests.test_job.task_b'
+        # if you run tests with standard ``--test-enable`
+        # the path is exactly 'openerp.addons.connector.tests.test_job.task_a'
+        # BUT if you run them using nose test from anybox recipe
+        # you get different path, like '..connector.tests.test_job.task_a'
+        # So, let's use `like` to match them in both cases.
+        self.assertTrue(
+            self.function_model.search([('name', 'like', '%' + path_a)])
+        )
+        self.assertTrue(
+            self.function_model.search([('name', 'like', '%' + path_b)])
+        )
 
     def test_channel_on_job(self):
         job(task_a)


### PR DESCRIPTION
1. currently the test `test_default_binder` is not tested at all on runbot
2. fix test_default_binder
3. make test_job work with nose

Unfortunately doctests loader in test_runner_channels.py do not work with nose, it throws this error:

```
ERROR: connector.tests.test_runner_channels.load_tests
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/path/to/nose-1.3.7-py2.7.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
TypeError: load_tests() takes exactly 3 arguments (0 given)
```
