### PR TITLE
Minor improvements and fixes for checkpoint views

### DIFF
--- a/connector/checkpoint/checkpoint_view.xml
+++ b/connector/checkpoint/checkpoint_view.xml
@@ -21,7 +21,7 @@
                     </header>
                     <sheet>
                         <h1>
-                            <div attrs="{'invisible': [('model_id', '!=', False)]}">
+                            <div attrs="{'invisible': [('model_id', '=', False)]}">
                                 Click on the <field name="model_id" class="oe_inline" options='{"no_open": 1}'/>
                                 to verify it:
                                 <field name="record"/>

--- a/connector/checkpoint/checkpoint_view.xml
+++ b/connector/checkpoint/checkpoint_view.xml
@@ -48,6 +48,7 @@
                         delete="false" edit="false" version="7.0">
                     <field name="model_id"/>
                     <field name="record"/>
+                    <field name="message"/>
                     <field name="backend_id"/>
                     <field name="state"/>
                     <button name="reviewed"


### PR DESCRIPTION
1. we don't want to show "Click on..." if there's no record linked!

![screenshot from 2016-10-19 16-30-49](https://cloud.githubusercontent.com/assets/347149/19523203/19353f16-961a-11e6-8d67-24bcb2d4a6fe.png)
1. `message` field was missing in tree view

At some point we should also put the message outside `H1` but this is another story :)
