### PR TITLE
[imp] add checkpoint straight from backend record

### DIFF
--- a/connector/AUTHORS
+++ b/connector/AUTHORS
@@ -22,3 +22,4 @@
 * Florent Thomas at Mind And Go
 * Matthieu Dietrich at Camptocamp
 * Olivier Laurent at Acsone
+* Simone Orsi at Camptocamp

--- a/connector/backend_model.py
+++ b/connector/backend_model.py
@@ -48,7 +48,7 @@ class ConnectorBackend(models.AbstractModel):
             raise ValueError('The backend %s has no _backend_type' % self)
         return backend.get_backend(self._backend_type, self.version)
 
-    @api.model
+    @api.multi
     def add_checkpoint(self, model=None, record_id=None, message=''):
         """Add a checkpoint for current backend."""
         self.ensure_one()

--- a/connector/backend_model.py
+++ b/connector/backend_model.py
@@ -49,7 +49,7 @@ class ConnectorBackend(models.AbstractModel):
         return backend.get_backend(self._backend_type, self.version)
 
     @api.multi
-    def add_checkpoint(self, model=None, record_id=None, message=''):
+    def add_checkpoint(self, model=None, record_id=None, message=None):
         """Add a checkpoint for current backend."""
         self.ensure_one()
         cp_model = self.env['connector.checkpoint']

--- a/connector/backend_model.py
+++ b/connector/backend_model.py
@@ -21,7 +21,6 @@
 
 from openerp import models, fields, api
 from . import backend
-from . import checkpoint
 
 
 class ConnectorBackend(models.AbstractModel):

--- a/connector/backend_model.py
+++ b/connector/backend_model.py
@@ -21,6 +21,7 @@
 
 from openerp import models, fields, api
 from . import backend
+from . import checkpoint
 
 
 class ConnectorBackend(models.AbstractModel):
@@ -46,6 +47,20 @@ class ConnectorBackend(models.AbstractModel):
         if self._backend_type is None:
             raise ValueError('The backend %s has no _backend_type' % self)
         return backend.get_backend(self._backend_type, self.version)
+
+    @api.model
+    def add_checkpoint(self, model=None, record_id=None, message=''):
+        """Add a checkpoint for current backend."""
+        self.ensure_one()
+        cp_model = self.env['connector.checkpoint']
+        res = None
+        if record_id and model:
+            res = cp_model.create_from_name(
+                model, record_id, self._name, self.id, message=message)
+        elif message:
+            res = cp_model.create_from_message(
+                self._name, self.id, message=message)
+        return res
 
 
 class ExternalBinding(models.AbstractModel):

--- a/connector/checkpoint/checkpoint.py
+++ b/connector/checkpoint/checkpoint.py
@@ -184,6 +184,8 @@ class ConnectorCheckpoint(models.Model):
         return [('state', '=', 'need_review')]
 
 
+# TODO: deprecate these since we can now add checkpoints
+# from the backend record itself.
 def add_checkpoint(session, model_name, record_id,
                    backend_model_name, backend_id, message=''):
     checkpoint_model = session.env['connector.checkpoint']

--- a/connector/checkpoint/checkpoint.py
+++ b/connector/checkpoint/checkpoint.py
@@ -31,6 +31,9 @@ so they appears in this list.
 
 from openerp import models, fields, api, _
 
+import logging
+_logger = logging.getLogger(__name__)
+
 
 class ConnectorCheckpoint(models.Model):
     _name = 'connector.checkpoint'
@@ -184,10 +187,12 @@ class ConnectorCheckpoint(models.Model):
         return [('state', '=', 'need_review')]
 
 
-# TODO: deprecate these since we can now add checkpoints
-# from the backend record itself.
 def add_checkpoint(session, model_name, record_id,
                    backend_model_name, backend_id, message=''):
+    _logger.warn(
+        "`add_checkpoint` is deprecated. "
+        "Please, use `backend_record.add_checkpoint`"
+    )
     checkpoint_model = session.env['connector.checkpoint']
     return checkpoint_model.create_from_name(model_name, record_id,
                                              backend_model_name, backend_id,
@@ -195,6 +200,10 @@ def add_checkpoint(session, model_name, record_id,
 
 
 def add_checkpoint_message(session, backend_model_name, backend_id, message):
+    _logger.warn(
+        "`add_checkpoint_message` is deprecated. "
+        "Please, use `backend_record.add_checkpoint`"
+    )
     checkpoint_model = session.env['connector.checkpoint']
     return checkpoint_model.create_from_message(
         backend_model_name, backend_id, message)

--- a/connector/doc/guides/bootstrap_connector.rst
+++ b/connector/doc/guides/bootstrap_connector.rst
@@ -201,30 +201,19 @@ Record checkpoint
 -----------------
 
 When new records are imported and need a review, :ref:`checkpoint` are
-created. I propose to create a helper too in
-``connector_coffee/connector.py``::
+created. You can add it like this::
 
-    from openerp.addons.connector.checkpoint import checkpoint
+    backend_record.add_checkpoint(
+        model='res.partner', record_id=1, message='VAT number can be missing')
 
-
-    def add_checkpoint(session, model_name, record_id, backend_id, message=''):
-        return checkpoint.add_checkpoint(session, model_name, record_id,
-                                         'coffee.backend', backend_id,
-                                         message=message)
 
 Message only checkpoint
 -----------------------
 
 When you need to show a warning message to a user
-you can create a :ref:`checkpoint`. I propose to create a helper too in
-``connector_coffee/connector.py``::
+you can create a :ref:`checkpoint`. You can add it like this::
 
-    from openerp.addons.connector.checkpoint import checkpoint
-
-
-    def add_checkpoint_message(session, backend_id, message):
-        return checkpoint.add_checkpoint_message(
-            session, 'coffee.backend', backend_id, message)
+    backend_record.add_checkpoint(message='VAT number can be missing')
 
 A typical use case for this is:
 

--- a/connector/tests/test_checkpoint.py
+++ b/connector/tests/test_checkpoint.py
@@ -59,3 +59,19 @@ class TestCheckpoint(common.TransactionCase):
         self.assertEqual(ckpoint.name, msg)
         self.assertEqual(ckpoint.backend_id.id, self.backend_record.id)
         self.assertTrue(ckpoint.message_follower_ids)
+
+    def test_add_checkpoint_from_backend(self):
+        backend_record = self.env['connector.backend'].new({'name': 'Test'})
+        # fake real id!
+        backend_record._ids = [99, ]
+        msg = "Yeah!"
+        ckpoint = backend_record.add_checkpoint(
+            model='res.partner', record_id=self.partner.id)
+        self.assertEqual(ckpoint.model_id.model, 'res.partner')
+        self.assertEqual(ckpoint.record_id, self.partner.id)
+        self.assertEqual(ckpoint.name, self.partner.display_name)
+        self.assertEqual(ckpoint.backend_id.id, 99)
+        self.assertTrue(ckpoint.message_follower_ids)
+
+        ckpoint = backend_record.add_checkpoint(message=msg)
+        self.assertEqual(ckpoint.message, msg)


### PR DESCRIPTION
Goal: simplify the checkpoint story.

**Now**

ATM you have to define this in your own code

```
from openerp.addons.connector.checkpoint import checkpoint

def add_checkpoint(session, model_name, record_id, backend_id, message=''):
    """Add checkpoint for prestashop backend."""
    return checkpoint.add_checkpoint(session, model_name, record_id,
                                     'prestashop.backend', backend_id)

def add_checkpoint_message(session, backend_id, message=''):
    """Add checkpoint message for prestashop backend."""
    return checkpoint.add_checkpoint_message(
        session, 'prestashop.backend', backend_id, message=message)
```

and then you have to import those functions, etc.

The point is: you always need your backend record to add a checkpoint.

**Improvement**

You just do this

```
backend_record.add_checkpoint(
        model='res.partner', record_id=1, message='VAT number can be missing')
```

or

```
backend_record.add_checkpoint(message='Failed import for category Foo')
```

Tests updated.
