### PR TITLE
Allow overriding of requests timeout value for long running tasks 

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -133,6 +133,7 @@ SELECT_TIMEOUT = 60
 ERROR_RECOVERY_DELAY = 5
 
 _logger = logging.getLogger(__name__)
+REQUEST_TIMEOUT = int(os.environ.get('REQUEST_TIMEOUT', 1))
 
 
 # Unfortunately, it is not possible to extend the Odoo
@@ -175,7 +176,7 @@ def _async_http_get(port, db_name, job_uuid):
         try:
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            requests.get(url, timeout=1)
+            requests.get(url, timeout=REQUEST_TIMEOUT)
         except requests.Timeout:
             set_job_pending()
         except:


### PR DESCRIPTION
The current value is set to 1sec. My job does little more than just creating records. When the timeout happens, it sometimes fails to set the job back to pending. I figured that situation will not arise if we don't let the timeout kick in. 

