### PR TITLE
[9.0] improve sequential channels

### DIFF
--- a/connector/jobrunner/channels.py
+++ b/connector/jobrunner/channels.py
@@ -403,6 +403,7 @@ class Channel(object):
 
         * capacity
         * sequential
+        * throttle
         """
         assert self.fullname.endswith(config['name'])
         self.capacity = config.get('capacity', None)

--- a/connector/producer.py
+++ b/connector/producer.py
@@ -51,6 +51,8 @@ def create(self, vals):
                                    context=self.env.context)
         on_record_create.fire(session, self._name, record_id.id, vals)
     return record_id
+
+
 models.BaseModel.create = create
 
 
@@ -68,6 +70,8 @@ def write(self, vals):
                 on_record_write.fire(session, self._name,
                                      record_id, vals)
     return result
+
+
 models.BaseModel.write = write
 
 
@@ -83,4 +87,6 @@ def unlink(self):
             for record_id in self.ids:
                 on_record_unlink.fire(session, self._name, record_id)
     return unlink_original(self)
+
+
 models.BaseModel.unlink = unlink


### PR DESCRIPTION
This implements a long standing todo regarding the behaviour of sequential channels in presence of ETA.

Jobs that get retried are  now correctly executed in the intended order if they are in a sequential channel.
This is useful for instance when doing long imports with base_import_async where the import order is important.