### PR TITLE
Fix E305 pep8 errors previously not detected

### DIFF
--- a/connector/connector.py
+++ b/connector/connector.py
@@ -379,6 +379,7 @@ class ConnectorEnvironment(object):
         else:
             return cls(backend_record, session, model)
 
+
 Environment = DeprecatedClass('Environment',
                               ConnectorEnvironment)
 

--- a/connector/producer.py
+++ b/connector/producer.py
@@ -51,6 +51,8 @@ def create(self, vals):
                                    context=self.env.context)
         on_record_create.fire(session, self._name, record_id.id, vals)
     return record_id
+
+
 models.BaseModel.create = create
 
 
@@ -68,6 +70,8 @@ def write(self, vals):
                 on_record_write.fire(session, self._name,
                                      record_id, vals)
     return result
+
+
 models.BaseModel.write = write
 
 
@@ -83,4 +87,6 @@ def unlink(self):
             for record_id in self.ids:
                 on_record_unlink.fire(session, self._name, record_id)
     return unlink_original(self)
+
+
 models.BaseModel.unlink = unlink

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -345,6 +345,7 @@ def start_service():
     watcher.daemon = True
     watcher.start()
 
+
 # We have to launch the Jobs Workers only if:
 # 0. The alternative connector runner is not enabled (i.e. no ``_channels()``)
 # 1. OpenERP is used in standalone mode (monoprocess)


### PR DESCRIPTION
The error text is:
E305 expected 2 blank lines after class or function definition, found 1