### PR TITLE
[9.0] [FWD] connector_job_subscribe (module to manage job subscription)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt

--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -155,8 +155,7 @@ class QueueJob(models.Model):
         return res
 
     @api.multi
-    def _subscribe_users(self):
-        """ Subscribe all users having the 'Connector Manager' group """
+    def _get_subscribe_users_domain(self):
         group = self.env.ref('connector.group_connector_manager')
         if not group:
             return
@@ -164,6 +163,12 @@ class QueueJob(models.Model):
         domain = [('groups_id', '=', group.id)]
         if companies:
             domain.append(('company_id', 'child_of', companies.ids))
+        return domain
+
+    @api.multi
+    def _subscribe_users(self):
+        """ Subscribe all users having the 'Connector Manager' group """
+        domain = self._get_subscribe_users_domain()
         users = self.env['res.users'].search(domain)
         self.message_subscribe_users(user_ids=users.ids)
 

--- a/connector_job_subscribe/README.rst
+++ b/connector_job_subscribe/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Connector Job Suscription
+===========================
+
+This module was written to extend the connector management. It allows to
+be member of group Connector manager without being follower of all jobs.
+This can avoid for some users to receive a lot of emails in case of failing
+jobs.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/connector/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/connector/issues/new?body
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/102/8.0
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/connector_job_subscribe/__init__.py
+++ b/connector_job_subscribe/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models
+from . import queue

--- a/connector_job_subscribe/__openerp__.py
+++ b/connector_job_subscribe/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{'name': 'Connector',
+ 'version': '9.0.1.0.0',
+ 'author': 'Acsone SA/Nv,'
+           'Odoo Community Association (OCA)',
+ 'website': 'http://www.acsone.eu',
+ 'license': 'AGPL-3',
+ 'category': 'Generic Modules',
+ 'depends': ['connector'
+             ],
+
+ 'data': [
+     'views/res_users_view.xml',
+ ],
+ 'installable': True,
+ }

--- a/connector_job_subscribe/models/__init__.py
+++ b/connector_job_subscribe/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import res_users

--- a/connector_job_subscribe/models/res_users.py
+++ b/connector_job_subscribe/models/res_users.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    subscribe_job = fields.Boolean('Jobs Notifications',
+                                   default=True,
+                                   help='If this flag is checked and the'
+                                        ' user is Connector Manager, he will'
+                                        ' receive job notifications.',
+                                   select=True)

--- a/connector_job_subscribe/queue/__init__.py
+++ b/connector_job_subscribe/queue/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import model

--- a/connector_job_subscribe/queue/model.py
+++ b/connector_job_subscribe/queue/model.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, models
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.multi
+    def _get_subscribe_users_domain(self):
+        domain = super(QueueJob, self)._get_subscribe_users_domain()
+        domain.append(('subscribe_job', '=', True))
+        return domain

--- a/connector_job_subscribe/tests/__init__.py
+++ b/connector_job_subscribe/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_job_subscribe

--- a/connector_job_subscribe/tests/test_job_subscribe.py
+++ b/connector_job_subscribe/tests/test_job_subscribe.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import openerp.tests.common as common
+
+from openerp.addons.connector.session import ConnectorSession
+from openerp.addons.connector.queue.job import (
+    Job,
+    OpenERPJobStorage,
+)
+
+
+def task_a(session, model_name):
+    """ Task description
+    """
+
+
+class TestJobSubscribe(common.TransactionCase):
+
+    def setUp(self):
+        super(TestJobSubscribe, self).setUp()
+        grp_connector_manager = self.ref("connector.group_connector_manager")
+        self.other_partner_a = self.env['res.partner'].create(
+            {"name": "My Company a",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        self.other_user_a = self.env['res.users'].create(
+            {"partner_id": self.other_partner_a.id,
+             "login": "my_login a",
+             "name": "my user",
+             "groups_id": [(4, grp_connector_manager)]
+             })
+        self.other_partner_b = self.env['res.partner'].create(
+            {"name": "My Company b",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        self.other_user_b = self.env['res.users'].create(
+            {"partner_id": self.other_partner_b.id,
+             "login": "my_login_b",
+             "name": "my user 1",
+             "groups_id": [(4, grp_connector_manager)]
+             })
+
+        self.session = ConnectorSession.from_env(self.env)
+
+    def _create_job(self):
+        test_job = Job(func=task_a)
+        storage = OpenERPJobStorage(self.session)
+        storage.store(test_job)
+        stored = storage.db_record_from_uuid(test_job.uuid)
+        self.assertEqual(len(stored), 1)
+        return stored
+
+    def test_job_subscription(self):
+        """
+            When a job is created, all user of group
+            connector.group_connector_manager are automatically set as
+            follower except if the flag subscribe_job is not set
+        """
+
+        #################################
+        # Test 1: All users are followers
+        #################################
+        stored = self._create_job()
+        stored._subscribe_users()
+        users = self.env['res.users'].search(
+            [('groups_id', '=', self.ref('connector.group_connector_manager'))]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(set(stored.mapped(
+            'message_follower_ids.partner_id')),
+            set(expected_partners))
+        followers_id = [f.id for f in stored.mapped(
+            'message_follower_ids.partner_id')]
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertIn(self.other_partner_b.id, followers_id)
+
+        ###########################################
+        # Test 2: User b request to not be follower
+        ###########################################
+        self.other_user_b.write({'subscribe_job': False})
+        stored = self._create_job()
+        stored._subscribe_users()
+        users = self.env['res.users'].search(
+            [('groups_id', '=', self.ref('connector.group_connector_manager')),
+             ('subscribe_job', '=', True)]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(set(stored.mapped(
+            'message_follower_ids.partner_id')),
+            set(expected_partners))
+        followers_id = [f.id for f in stored.mapped(
+            'message_follower_ids.partner_id')]
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertNotIn(self.other_partner_b.id, followers_id)

--- a/connector_job_subscribe/views/res_users_view.xml
+++ b/connector_job_subscribe/views/res_users_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data noupdate="0">
+        <record id="view_user_connector_form" model="ir.ui.view">
+            <field name="name">res.user.connector.form</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form" />
+            <field name="arch" type="xml">
+                <xpath expr="/form/sheet/notebook" position="inside">
+                    <page string="Connectors" name="connector">
+                        <group>
+                            <field name="subscribe_job"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/setup/connector_job_subscribe/odoo_addons/__init__.py
+++ b/setup/connector_job_subscribe/odoo_addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_job_subscribe/odoo_addons/connector_job_subscribe
+++ b/setup/connector_job_subscribe/odoo_addons/connector_job_subscribe
@@ -1,0 +1,1 @@
+../../../connector_job_subscribe

--- a/setup/connector_job_subscribe/setup.py
+++ b/setup/connector_job_subscribe/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Forward port of #227 

> Sometimes, user must manage jobs and must be Connector manager but they don't want to receive mails or notifications.
This new module adds a flag on user form to let him the choice of receiving notifications or not.