### PR TITLE
[ADD] configurable scheme, host and http auth

### DIFF
--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -48,8 +48,25 @@ class ConnectorRunnerThread(Thread):
     def __init__(self):
         Thread.__init__(self)
         self.daemon = True
-        port = os.environ.get('ODOO_CONNECTOR_PORT') or config['xmlrpc_port']
-        self.runner = ConnectorRunner(port or 8069)
+        scheme = (os.environ.get('ODOO_CONNECTOR_SCHEME') or
+                  config.misc.get("options-connector", {}).get('scheme'))
+        host = (os.environ.get('ODOO_CONNECTOR_HOST') or
+                config.misc.get("options-connector", {}).get('host') or
+                config['xmlrpc_interface'])
+        port = (os.environ.get('ODOO_CONNECTOR_PORT') or
+                config.misc.get("options-connector", {}).get('port') or
+                config['xmlrpc_port'])
+        user = (os.environ.get('ODOO_CONNECTOR_HTTP_AUTH_USER') or
+                config.misc.get("options-connector", {}).
+                get('http_auth_user'))
+        password = (os.environ.get('ODOO_CONNECTOR_HTTP_AUTH_PASSWORD') or
+                    config.misc.get("options-connector", {}).
+                    get('http_auth_password'))
+        self.runner = ConnectorRunner(scheme or 'http',
+                                      host or 'localhost',
+                                      port or 8069,
+                                      user,
+                                      password)
 
     def run(self):
         # sleep a bit to let the workers start at ease

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -45,14 +45,20 @@ How to use it?
 
 * By default, the job runner will use Odoo's configuration:
 
-  - connect to Odoo via port ``xmlrpc_port``, or ``8069`` if unset
+  - connect to Odoo via
+    - host ``xmlrpc_interface`` or ``localhost`` if unset
+    - port ``xmlrpc_port``, or ``8069`` if unset
   - connect to the database via ``db_host`` and ``db_port``
 
 * To adjust these values, you can either use environment variables:
 
-  - ``ODOO_CONNECTOR_PORT=9069``
-  - ``ODOO_CONNECTOR_JOBRUNNER_DB_HOST=127.0.2.1``
-  - ``ODOO_CONNECTOR_JOBRUNNER_DB_PORT=15432``
+  - ``ODOO_CONNECTOR_SCHEME=https``
+  - ``ODOO_CONNECTOR_HOST=load-balancer``
+  - ``ODOO_CONNECTOR_PORT=443``
+  - ``ODOO_CONNECTOR_HTTP_AUTH_USER=connector``
+  - ``ODOO_CONNECTOR_HTTP_AUTH_PASSWORD=s3cr3t``
+  - ``ODOO_CONNECTOR_JOBRUNNER_DB_HOST=master-db``
+  - ``ODOO_CONNECTOR_JOBRUNNER_DB_PORT=5432``
 
 * Or alternatively, you can add a ``[options-connector]`` section in Odoo's
   configuration file, like this:
@@ -60,8 +66,13 @@ How to use it?
 .. code-block:: ini
 
   [options-connector]
-  jobrunner_db_host = 127.0.2.1
-  jobrunner_db_port = 15432
+  scheme = https
+  host = load-balancer
+  port = 443
+  http_auth_user = connector
+  http_auth_password = s3cr3t
+  jobrunner_db_host = master-db
+  jobrunner_db_port = 5432
 
 * Start Odoo with ``--load=web,web_kanban,connector``
   and ``--workers`` greater than 1. [2]_
@@ -176,7 +187,7 @@ def _connection_info_for(db_name):
     return connection_info
 
 
-def _async_http_get(port, db_name, job_uuid):
+def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
@@ -194,12 +205,15 @@ def _async_http_get(port, db_name, job_uuid):
     #       if this was python3 I would be doing this with
     #       asyncio, aiohttp and aiopg
     def urlopen():
-        url = ('http://localhost:%s/connector/runjob?db=%s&job_uuid=%s' %
-               (port, db_name, job_uuid))
+        url = ('%s://%s:%s/connector/runjob?db=%s&job_uuid=%s' %
+               (scheme, host, port, db_name, job_uuid))
         try:
+            auth = None
+            if user:
+                auth = (user, password)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = requests.get(url, timeout=1)
+            response = requests.get(url, timeout=1, auth=auth)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error
@@ -294,8 +308,18 @@ class Database(object):
 
 class ConnectorRunner(object):
 
-    def __init__(self, port=8069, channel_config_string=None):
+    def __init__(self,
+                 scheme='http',
+                 host='localhost',
+                 port=8069,
+                 user=None,
+                 password=None,
+                 channel_config_string=None):
+        self.scheme = scheme
+        self.host = host
         self.port = port
+        self.user = user
+        self.password = password
         self.channel_manager = ChannelManager()
         if channel_config_string is None:
             channel_config_string = _channels()
@@ -341,7 +365,13 @@ class ConnectorRunner(object):
             _logger.info("asking Odoo to run job %s on db %s",
                          job.uuid, job.db_name)
             self.db_by_name[job.db_name].set_job_enqueued(job.uuid)
-            _async_http_get(self.port, job.db_name, job.uuid)
+            _async_http_get(self.scheme,
+                            self.host,
+                            self.port,
+                            self.user,
+                            self.password,
+                            job.db_name,
+                            job.uuid)
 
     def process_notifications(self):
         for db in self.db_by_name.values():


### PR DESCRIPTION
In some deployments we can have multiple Odoo instances running on the same host, each of them listening on a different interface.

This PR makes it possible to configure the host part of the URL called by the Job Runner to run jobs, instead of the currently harcoded "localhost".

Two alternative methods to configure said host:
- standard Odoo _xmlrpc_interface_ parameter
- _ODOO_CONNECTOR_HOST_ environment variable
