### PR TITLE
[ADD] configurable db host and port

### DIFF
--- a/connector/doc/guides/jobrunner.rst
+++ b/connector/doc/guides/jobrunner.rst
@@ -2,7 +2,7 @@
 
 
 #######################################
-Configuring channels and the job runner
+Configuring the job runner and channels
 #######################################
 
 .. automodule:: connector.jobrunner.runner
@@ -18,7 +18,7 @@ How to configure Channels?
 The ``ODOO_CONNECTOR_CHANNELS`` environment variable can be
 set before starting Odoo in order to adjust the capacity of the channels.
 
-Alternatively, set the channel configuration in the Odoo configuration file:
+Alternatively, set the channels configuration in the Odoo configuration file:
 
 .. code-block:: cfg
 


### PR DESCRIPTION
In some deployments, we might want the Job Runner to connect to the database through a different host/port couple than Odoo.

This is required for example if you have a PgBouncer configured in transaction mode: the Job Runner relies on LISTEN/NOTIFY features, which are not supported by said transaction mode. This PR makes it possible to bypass PgBouncer by adding support for _jobrunner_db_host_ and _jobrunner_db_port_ parameters in Odoo's configuration file.