### PR TITLE
[add] jobs filter `Created last 24h`

### DIFF
--- a/connector/__openerp__.py
+++ b/connector/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 {'name': 'Connector',
- 'version': '9.0.1.0.3',
+ 'version': '9.0.1.1.0',
  'author': 'Camptocamp,Openerp Connector Core Editors,'
            'Odoo Community Association (OCA)',
  'website': 'http://odoo-connector.com',

--- a/connector/queue/model_view.xml
+++ b/connector/queue/model_view.xml
@@ -118,6 +118,8 @@
                         domain="[('state', '=', 'done')]"/>
                     <filter name="failed" string="Failed"
                         domain="[('state', '=', 'failed')]"/>
+                    <filter name="created_last_24h" string="Created Last 24h"
+                            domain="[('date_created','&gt;', (context_today() - datetime.timedelta(days=1)).strftime('%%Y-%%m-%%d') )]"/>
                     <group expand="0" string="Group By">
                         <filter string="Channel" context="{'group_by': 'channel'}" />
                         <filter string="Job Function" context="{'group_by': 'job_function_id'}" />


### PR DESCRIPTION
When you check the queue most of the times
you want to see jobs created today
while you are "playing" with the connector.

I can add this to `queue_job` on v10 if consireded useful.