### PR TITLE
[FIX] mapper: Remove orphan method _map_children

### DIFF
--- a/connector/unit/mapper.py
+++ b/connector/unit/mapper.py
@@ -634,9 +634,6 @@ class Mapper(ConnectorUnit):
         """
         raise NotImplementedError
 
-    def _map_children(self, record, attr, model):
-        raise NotImplementedError
-
     @property
     def map_methods(self):
         """ Yield all the methods decorated with ``@mapping`` """


### PR DESCRIPTION
This method is not used by the connector and generate errors with pylint if it's not implemented in concrete class.

CC @guewen 