### PR TITLE
[ADD] 8.0 Take into account HTTP response codes when assigning work

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -175,7 +175,12 @@ def _async_http_get(port, db_name, job_uuid):
         try:
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            requests.get(url, timeout=1)
+            response = requests.get(url, timeout=1)
+
+            # raise_for_status will result in either nothing, a Client Error
+            # for HTTP Response codes between 400 and 500 or a Server Error
+            # for codes between 500 and 600
+            response.raise_for_status()
         except requests.Timeout:
             set_job_pending()
         except:


### PR DESCRIPTION
In our proxy setup we've foreseen potential cases where the proxy would answer a jobrunner with a 503 HTTP error code in case the chosen Odoo backend server would be too busy for answering the jobrunners call while assigning a job.

We would like to propose this change to take into account HTTP error response codes (400 through 600) and just raise when this happens. This will cause the same behaviour as when having a timeout on our call.