### PR TITLE
[10.0][FIX] connector : Avoid creating void child values

### DIFF
--- a/connector/components/mapper.py
+++ b/connector/components/mapper.py
@@ -338,7 +338,9 @@ class MapChild(AbstractComponent):
             map_record = mapper.map_record(item, parent=parent)
             if self.skip_item(map_record):
                 continue
-            mapped.append(self.get_item_values(map_record, to_attr, options))
+            item_values = self.get_item_values(map_record, to_attr, options)
+            if item_values:
+                mapped.append(item_values)
         return self.format_items(mapped)
 
     def get_item_values(self, map_record, to_attr, options):


### PR DESCRIPTION
When there is no direct mapping and child elements are filtered and return no value,
the resulting record to write is like {'field_xxx': 'value', child_ids': [(0, 0, {})]}