### PR TITLE
Use a requests session to limit opened sessions

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -68,6 +68,18 @@ class RunJobController(http.Controller):
             self.job_storage_class(session).store(job)
         _logger.debug('%s done', job)
 
+    @http.route('/connector/session', type='http', auth="none")
+    def session(self):
+        """ Used by the jobrunner to spawn a session
+
+        The connector jobrunner uses anonymous sessions when it calls
+        ``/connnector/runjob``.  To avoid having thousands of anonymous
+        sessions, before running jobs, it creates a ``requests.Session``
+        and does a GET on ``/connector/session``, providing it a cookie
+        which will be used for subsequent calls to runjob.
+        """
+        return ''
+
     @http.route('/connector/runjob', type='http', auth='none')
     def runjob(self, db, job_uuid, **kw):
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -146,6 +146,9 @@ ERROR_RECOVERY_DELAY = 5
 _logger = logging.getLogger(__name__)
 
 
+session = requests.Session()
+
+
 # Unfortunately, it is not possible to extend the Odoo
 # server command line arguments, so we resort to environment variables
 # to configure the runner (channels mostly).
@@ -172,8 +175,6 @@ def _openerp_now():
     dt = datetime.datetime.utcnow()
     return _datetime_to_epoch(dt)
 
-session = requests.Session()
-
 
 def _connection_info_for(db_name):
     db_or_uri, connection_info = openerp.sql_db.connection_info_for(db_name)
@@ -190,6 +191,17 @@ def _connection_info_for(db_name):
 
 
 def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
+
+    if not session.cookies:
+        # obtain an anonymous session
+        _logger.info("obtaining an anonymous session for the job runner")
+        url = ('%s://%s:%s/connector/session' % (scheme, host, port))
+        auth = None
+        if user:
+            auth = (user, password)
+        response = session.get(url, timeout=30, auth=auth)
+        response.raise_for_status()
+
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
@@ -225,6 +237,7 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
             set_job_pending()
         except:
             _logger.exception("exception in GET %s", url)
+            session.cookies.clear()
             set_job_pending()
     thread = threading.Thread(target=urlopen)
     thread.daemon = True

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -172,6 +172,8 @@ def _openerp_now():
     dt = datetime.datetime.utcnow()
     return _datetime_to_epoch(dt)
 
+session = requests.Session()
+
 
 def _connection_info_for(db_name):
     db_or_uri, connection_info = openerp.sql_db.connection_info_for(db_name)
@@ -213,7 +215,7 @@ def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
                 auth = (user, password)
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = requests.get(url, timeout=1, auth=auth)
+            response = session.get(url, timeout=1, auth=auth)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error


### PR DESCRIPTION
We have some issues with a very high throughput of jobs and Odoo's
anonymous sessions. Every job pushed to Odoo uses a new anonymous
sessions, which creates a tremendous amount of session files.

Using a requests.session means that the session will keep the same
cookie once it receives the first response.

There is 2 problems with the usage of a session though:

* requests.Session is not proved to be threadsafe [0]
Anyway as they are all anonymous, if we lose or mix up odoo sessions at some point it should work as well.
* the main issue is that we don't wait for an answer so until we have a
requests responding before the timeout we won't have any session id

The second issue is resolved in the last commit with a pre-request to obtain a cookie.
When we run a job, we don't wait for the answer. So when we don't have
any cookie yet, we send a GET on a very fast controller route which will
return a cookie, used for all the subsequents calls to runjob.

This effectively prevent to create one session file per job.

I tested it on my side on a large amount of jobs, but extra testing could be helpful. 
What I did not test:
* odoo on a different host / with auth.
* keep it running over a long span of time