### PR TITLE
[10.0][FIX] component: Cachetools versioning

### DIFF
--- a/setup/component/setup.py
+++ b/setup/component/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     odoo_addons={
         'external_dependencies_override': {
             'python': {
-                'cachetools': 'cachetools>2.0.1',
+                'cachetools': 'cachetools>=2.0.1',
             }
         }
     }


### PR DESCRIPTION
* Change cachetools version to >=2.0.1 in setup.py (version > 2.0.1 not yet exists)