### PR TITLE
[8.0] Not only check for operational error's but also retry InternalError's of Psycopg2's layer

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -2,7 +2,7 @@ import logging
 import traceback
 from cStringIO import StringIO
 
-from psycopg2 import OperationalError
+from psycopg2 import OperationalError, InternalError, errorcodes
 
 import openerp
 from openerp import http, tools
@@ -20,7 +20,7 @@ from ..exception import (NoSuchJobError,
 _logger = logging.getLogger(__name__)
 
 PG_RETRY = 5  # seconds
-
+PG_INTERNAL_ERRORS_TO_RETRY = [errorcodes.IN_FAILED_SQL_TRANSACTION]
 
 # TODO: perhaps the notion of ConnectionSession is less important
 #       now that we are running jobs inside a normal Odoo worker
@@ -88,15 +88,17 @@ class RunJobController(http.Controller):
         try:
             try:
                 self._try_perform_job(session_hdl, job)
-            except OperationalError as err:
+            except (OperationalError, InternalError) as err:
                 # Automatically retry the typical transaction serialization
                 # errors
-                if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY:
+                if err.pgcode not in PG_CONCURRENCY_ERRORS_TO_RETRY and \
+                        err.pgcode not in PG_INTERNAL_ERRORS_TO_RETRY:
                     raise
 
                 retry_postpone(job, tools.ustr(err.pgerror, errors='replace'),
                                seconds=PG_RETRY)
-                _logger.debug('%s OperationalError, postponed', job)
+                _logger.debug(
+                    '%s OperationalError or InternalError, postponed', job)
 
         except NothingToDoJob as err:
             if unicode(err):


### PR DESCRIPTION
We had the use-case where we also try/catch exceptions of the ORM layers inside our connector jobs, in rare cases of crossing jobs we could trigger an InternalError on the Psycopg2's layer inside our job. 

The error is "IN_FAILED_SQL_TRANSACTION", we consider this to be a retryable error that could be catched on the same level as operational errors. 