### PR TITLE
Refine lookup on specific model over generic component

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -108,7 +108,7 @@ class ComponentRegistry(object):
         """ Find and return a list of components for a usage
 
         If a component is not registered in a particular collection (no
-        ``_collection``), it might will be returned in any case (as far as
+        ``_collection``), it will be returned in any case (as far as
         the ``usage`` and ``model_name`` match).  This is useful to share
         generic components across different collections.
 
@@ -356,6 +356,14 @@ class WorkContext(object):
         :meth:`ComponentRegistry.lookup`. When a component is found,
         it initialize it with the current :class:`WorkContext` and returned.
 
+        A component with a ``_apply_on`` matching the asked ``model_name``
+        takes precedence over a generic component without ``_apply_on``.
+        A component with a ``_collection`` matching the current collection
+        takes precedence over a generic component without ``_collection``.
+        This behavior allows to define generic components across collections
+        and/or models and override them only for a particular collection and/or
+        model.
+
         A :exc:`odoo.addons.component.exception.SeveralComponentError` is
         raised if more than one component match for the provided
         ``usage``/``model_name``.
@@ -378,10 +386,16 @@ class WorkContext(object):
             )
         elif len(component_classes) > 1:
             # If we have more than one component, try to find the one
-            # specificaly linked to the collection
+            # specifically linked to the collection...
             component_classes = [
                 c for c in component_classes
                 if c._collection == self.collection._name]
+        if len(component_classes) > 1:
+            # ... or try to find the one specifically linked to the model
+            component_classes = [
+                c for c in component_classes
+                if c.apply_on_models and model_name in c.apply_on_models
+            ]
         if len(component_classes) != 1:
             raise SeveralComponentError(
                 "Several components found for collection '%s', "

--- a/component/tests/test_component.py
+++ b/component/tests/test_component.py
@@ -158,9 +158,59 @@ class TestComponent(TransactionComponentRegistryCase):
             self.assertEquals(self.env['res.users'], comp.model)
 
     def test_component_error_several(self):
-        """ Use component(usage=...) when more than one component match """
+        """ Use component(usage=...) when more than one generic component match
+        """
+        # we create 1 new Component with _usage 'for.test', in the same
+        # collection and no _apply_on, and we remove the _apply_on of component
+        # 1 so they are generic components for a collection
+        class Component3(Component):
+            _name = 'component3'
+            _collection = 'collection.base'
+            _usage = 'for.test'
+
+        class Component1(Component):
+            _inherit = 'component1'
+            _collection = 'collection.base'
+            _usage = 'for.test'
+            _apply_on = None
+
+        Component3._build_component(self.comp_registry)
+        Component1._build_component(self.comp_registry)
+
+        with self.get_base() as base:
+            with self.assertRaises(SeveralComponentError):
+                # When a component has no _apply_on, it means it can be applied
+                # on *any* model. Here, the candidates components would be:
+                # component3 (because it has no _apply_on so apply in any case)
+                # component4 (for the same reason)
+                base.component(usage='for.test')
+
+    def test_component_error_several_same_model(self):
+        """ Use component(usage=...) when more than one component match a model
+        """
         # we create a new Component with _usage 'for.test', in the same
         # collection and no _apply_on
+        class Component3(Component):
+            _name = 'component3'
+            _collection = 'collection.base'
+            _usage = 'for.test'
+            _apply_on = ['res.partner']
+
+        Component3._build_component(self.comp_registry)
+
+        with self.get_base() as base:
+            with self.assertRaises(SeveralComponentError):
+                # Here, the candidates components would be:
+                # component1 (because we are working with res.partner),
+                # component3 (for the same reason)
+                base.component(usage='for.test')
+
+    def test_component_specific_model(self):
+        """ Use component(usage=...) when more than one component match but
+        only one for the specific model"""
+        # we create a new Component with _usage 'for.test', in the same
+        # collection and no _apply_on. This is a generic component for the
+        # collection
         class Component3(Component):
             _name = 'component3'
             _collection = 'collection.base'
@@ -169,12 +219,17 @@ class TestComponent(TransactionComponentRegistryCase):
         Component3._build_component(self.comp_registry)
 
         with self.get_base() as base:
-            with self.assertRaises(SeveralComponentError):
-                # When a component has no _apply_on, it means it can be applied
-                # on *any* model. Here, the candidates components would be:
-                # component1 (because we are working with res.partner),
-                # component3 (because it has no _apply_on so apply in any case)
-                base.component(usage='for.test')
+            # When a component has no _apply_on, it means it can be applied on
+            # *any* model. Here, the candidates components would be:
+            # component1 # (because we are working with res.partner),
+            # component3 (because it # has no _apply_on so apply in any case).
+            # When a component is specifically linked to a model with
+            # _apply_on, it takes precedence over a generic component. It
+            # allows to create a generic implementation (component3 here) and
+            # override it only for a given model. So in this case, the final
+            # component is component1.
+            comp = base.component(usage='for.test')
+            self.assertEquals('component1', comp._name)
 
     def test_component_specific_collection(self):
         """ Use component(usage=...) when more than one component match but
@@ -196,6 +251,35 @@ class TestComponent(TransactionComponentRegistryCase):
             # on all model if no component is found for the current collection:
             # component3 must be ignored since a component (component1) exists
             # and is specificaly linked to the expected collection.
+            comp = base.component(usage='for.test')
+            self.assertEquals('component1', comp._name)
+
+    def test_component_specific_collection_specific_model(self):
+        """ Use component(usage=...) when more than one component match but
+        only one for the specific model and collection"""
+        # we create a new Component with _usage 'for.test', without collection
+        # and no _apply_on. This is a component generic for all collections and
+        # models
+        class Component3(Component):
+            _name = 'component3'
+            _usage = 'for.test'
+
+        Component3._build_component(self.comp_registry)
+
+        with self.get_base() as base:
+            # When a component has no _apply_on, it means it can be applied on
+            # *any* model, no _collection, it can be applied on *any*
+            # collection.
+            # Here, the candidates components would be:
+            # component1 (because we are working with res.partner),
+            # component3 (because it has no _apply_on and no _collection so
+            # apply in any case).
+            # When a component is specifically linked to a model with
+            # _apply_on, it takes precedence over a generic component, the same
+            # happens for collection. It allows to create a generic
+            # implementation (component3 here) and override it only for a given
+            # collection and model. So in this case, the final component is
+            # component1.
             comp = base.component(usage='for.test')
             self.assertEquals('component1', comp._name)
 


### PR DESCRIPTION
With components having a generic implementation and another
one linked with a model such as:

```python

  class GenericExporter(Component):

      _name = 'generic.exporter'
      _inherit = ['base.exporter']
      _usage = 'record.exporter'

      def run(self, records):
          return self._export_items(records)

  class SaleExporter(Component):

      _name = 'sale.exporter'
      _inherit = ['generic.exporter']
      _apply_on = 'sale.order'

      def run(self, records):
          return self.do_stuff(records)
```

The previous behavior with this code:

```python
exporter = work.component('record.exporter')
```

Was to raise an error:
```
SeveralComponentError: Several components found for collection 'xx.backend',
usage 'record.exporter', model_name 'sale.order'. Found: [<class
'odoo.addons.component.core.generic.exporter'>, <class
'odoo.addons.component.core.sale.exporter'>]
```

This commit refines the lookup so if a specific Component is linked with the
asked model, it will be returned over the generic one. It allows to build
generic components and override them only in some use cases.

Follows the motivation of #272 but as a model's level instead of collection.

Closes #276