### PR TITLE
connector_event: Disable trigger if registry is not ready

### DIFF
--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -75,6 +75,8 @@ class Base(models.AbstractModel):
             # during the initialization. Hence we return an empty list of
             # events, the 'notify' calls will do nothing.
             return CollectedEvents([])
+        if not comp_registry.get('base.event.collecter'):
+            return CollectedEvents([])
 
         model_name = self._name
         if collection is not None:


### PR DESCRIPTION
During install / upgrade of addons, the odoo registry is recreated and not
flagged as ready. At the end of the odoo registry loading, the registry
of components will be built. If we install component_event from the UI
(not with -i), the component's registry is already flagged as "ready",
but the 'base.event.collecter' component is not yet referenced in it.

Inhibiting the trigger of event when the odoo registry is ready will
prevent this issue. It means that no event will be triggered when the
install or upgrade of addons should trigger them but this was already
the case when using the "-i" install of addons.

Fixes #279 