### PR TITLE
Fix cachetools dependency version

### DIFF
--- a/setup/component/setup.py
+++ b/setup/component/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     odoo_addons={
         'external_dependencies_override': {
             'python': {
-                'cachetools': 'cachetools>2.0.1',
+                'cachetools': 'cachetools>=2.0.1',
             }
         }
     }


### PR DESCRIPTION
The current version of cachetools is 2.0.1, so > won't work.
The dependency in the requirements.txt is >=2.0.1