### PR TITLE
[IMP] Jobrunner as a worker

### DIFF
--- a/connector/jobrunner/__init__.py
+++ b/connector/jobrunner/__init__.py
@@ -61,32 +61,57 @@ class ConnectorRunnerThread(Thread):
         self.runner.stop()
 
 
+class WorkerJobRunner(server.Worker):
+    """ Jobrunner workers """
+
+    def __init__(self, multi):
+        super(WorkerJobRunner, self).__init__(multi)
+        self.watchdog_timeout = None
+        port = os.environ.get('ODOO_CONNECTOR_PORT') or config['xmlrpc_port']
+        base_url = port and 'http://localhost:%s' % port \
+                   or 'http://localhost:8069'
+        channels = _channels()
+        self.runner = ConnectorRunner(base_url, channels or 'root:1')
+
+    def sleep(self):
+        pass
+
+    def signal_handler(self, sig, frame):
+        _logger.debug("WorkerJobRunner (%s) received signal %s", self.pid, sig)
+        super(WorkerJobRunner, self).signal_handler(sig, frame)
+        self.runner.stop()
+
+    def process_work(self):
+        _logger.debug("WorkerJobRunner (%s) starting up", self.pid)
+        time.sleep(START_DELAY)
+        self.runner.run()
+
+
 runner_thread = None
 
-orig_prefork_start = server.PreforkServer.start
-orig_prefork_stop = server.PreforkServer.stop
+orig_prefork__init__ = server.PreforkServer.__init__
+orig_prefork_process_spawn = server.PreforkServer.process_spawn
+orig_prefork_worker_pop = server.PreforkServer.worker_pop
 orig_threaded_start = server.ThreadedServer.start
 orig_threaded_stop = server.ThreadedServer.stop
 
 
-def prefork_start(server, *args, **kwargs):
-    global runner_thread
-    res = orig_prefork_start(server, *args, **kwargs)
-    if _channels() and not config['stop_after_init']:
-        _logger.info("starting jobrunner thread (in prefork server)")
-        runner_thread = ConnectorRunnerThread()
-        runner_thread.start()
+def prefork__init__(server, app):
+    res = orig_prefork__init__(server, app)
+    server.jobrunner = {}
     return res
 
 
-def prefork_stop(server, graceful=True):
-    global runner_thread
-    if runner_thread:
-        runner_thread.stop()
-    res = orig_prefork_stop(server, graceful)
-    if runner_thread:
-        runner_thread.join()
-        runner_thread = None
+def prefork_process_spawn(server):
+    orig_prefork_process_spawn(server)
+    if not server.jobrunner and _channels():
+        server.worker_spawn(WorkerJobRunner, server.jobrunner)
+
+
+def prefork_worker_pop(server, pid):
+    res = orig_prefork_worker_pop(server, pid)
+    if pid in server.jobrunner:
+        server.jobrunner.pop(pid)
     return res
 
 
@@ -111,7 +136,8 @@ def threaded_stop(server):
     return res
 
 
-server.PreforkServer.start = prefork_start
-server.PreforkServer.stop = prefork_stop
+server.PreforkServer.__init__ = prefork__init__
+server.PreforkServer.process_spawn = prefork_process_spawn
+server.PreforkServer.worker_pop = prefork_worker_pop
 server.ThreadedServer.start = threaded_start
 server.ThreadedServer.stop = threaded_stop

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -373,10 +373,14 @@ class ConnectorRunner(object):
                     self.wait_notification()
             except KeyboardInterrupt:
                 self.stop()
-            except:
-                _logger.exception("exception: sleeping %ds and retrying",
-                                  ERROR_RECOVERY_DELAY)
-                self.close_databases()
-                time.sleep(ERROR_RECOVERY_DELAY)
+            except Exception as e:
+                # Interrupted system call, i.e. KeyboardInterrupt during select
+                if isinstance(e, select.error) and e[0] == 4:
+                    self.stop()
+                else:
+                    _logger.exception("exception: sleeping %ds and retrying",
+                                      ERROR_RECOVERY_DELAY)
+                    self.close_databases()
+                    time.sleep(ERROR_RECOVERY_DELAY)
         self.close_databases(remove_jobs=False)
         _logger.info("stopped")


### PR DESCRIPTION
We have some memory issues with the job runner, especially when there are 30000 pending jobs (and 30000 ChannelJobs in the uuid registry). The biggest problem is that the job runner lives as a thread in the main process, so that when a new worker is forked, its memory is forked into it. If your soft process memory limit is not outrageous, it could be that it is exceeded at the start of the worker lifecycle so that you get into a loop in which each new worker is retired after one request. This PR suggests as a solution to let the jobrunner live in its own worker.