### PR TITLE
[9.0] [FIX] Queue Job: delete messages when deleting job

### DIFF
--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -213,6 +213,19 @@ class QueueJob(models.Model):
         jobs.unlink()
         return True
 
+    @api.multi
+    def unlink(self):
+        """
+        This override unlinks the messages (mail.message) linked to
+        deleted jobs.
+        """
+        queue_job_ids = self.ids
+        res = super(QueueJob, self).unlink()
+        self.env['mail.message'].search([
+            ('model', '=', self._name),
+            ('res_id', 'in', queue_job_ids)]).unlink()
+        return res
+
 
 class RequeueJob(models.TransientModel):
     _name = 'queue.requeue.job'


### PR DESCRIPTION
### Issue
* Autovacuum delete jobs and let the mail messages in the database
* It results with a growing number of unread messages (needaction) impossible to set to read via the UI

### In this PR
* Override `unlink` to delete the messages when deleting a job