### PR TITLE
[8.0] mail_connector_queue: rename field & fetch priority from context

### DIFF
--- a/mail_connector_queue/README.rst
+++ b/mail_connector_queue/README.rst
@@ -37,6 +37,15 @@ A queue job is created automatically when a new ``mail.mail`` record is
 created in the ``outgoing`` state. A priority may be defined in the
 ``mail.mail`` record, which will be used as the job priority.
 
+Changelog
+=========
+
+8.0.1.0.1 (2018-05-28)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Priority field renamed to ``mail_job_priority``
+* Priority can now be passed using the context
+
 Bug Tracker
 ===========
 

--- a/mail_connector_queue/__openerp__.py
+++ b/mail_connector_queue/__openerp__.py
@@ -6,7 +6,7 @@
     'name': 'Mail Connector Queue',
     'summary': """
         Email Connector Queue""",
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/connector',

--- a/mail_connector_queue/job.py
+++ b/mail_connector_queue/job.py
@@ -22,8 +22,9 @@ def send_mail(session, mail_id):
 
 def queue_job(session, record_id, vals):
     kwargs = {}
-    if 'priority' in vals:
-        kwargs['priority'] = vals['priority']
+    record = session.env['mail.mail'].browse(record_id)
+    if record.mail_job_priority:
+        kwargs['priority'] = record.mail_job_priority
     send_mail.delay(session, record_id, **kwargs)
 
 

--- a/mail_connector_queue/models/mail_mail.py
+++ b/mail_connector_queue/models/mail_mail.py
@@ -9,4 +9,4 @@ class MailMail(models.Model):
 
     _inherit = 'mail.mail'
 
-    priority = fields.Integer()
+    mail_job_priority = fields.Integer(oldname='priority')

--- a/mail_connector_queue/readme/HISTORY.rst
+++ b/mail_connector_queue/readme/HISTORY.rst
@@ -1,0 +1,5 @@
+8.0.1.0.1 (2018-05-28)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Priority field renamed to ``mail_job_priority``
+* Priority can now be passed using the context

--- a/mail_connector_queue/views/mail_mail.xml
+++ b/mail_connector_queue/views/mail_mail.xml
@@ -11,7 +11,7 @@
         <field name="inherit_id" ref="mail.view_mail_form"/>
         <field name="arch" type="xml">
             <field name="auto_delete" position="after">
-                <field name="priority"/>
+                <field name="mail_job_priority"/>
             </field>
         </field>
     </record>
@@ -22,7 +22,7 @@
         <field name="inherit_id" ref="mail.view_mail_tree"/>
         <field name="arch" type="xml">
             <field name="date" position="after">
-                <field name="priority"/>
+                <field name="mail_job_priority"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
These commits make the field purpose more explicit, and allow passing the priority using the context, as suggested by the original issue #286 but not implemented in the previous PR.