### PR TITLE
[10.0] [IMP] component_event

### DIFF
--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -75,6 +75,8 @@ class Base(models.AbstractModel):
             # during the initialization. Hence we return an empty list of
             # events, the 'notify' calls will do nothing.
             return CollectedEvents([])
+        if not comp_registry.get('base.event.collecter'):
+            return CollectedEvents([])
 
         model_name = self._name
         if collection is not None:


### PR DESCRIPTION
Component Event
=============

This will fix the issus and adds the condition, event should not be triggered before the registry has been loaded.

Backport PR #283 to v10.0