### PR TITLE
11.0 Fix docs build and improve documentation of APIs

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -628,15 +628,19 @@ class AbstractComponent(object, metaclass=MetaComponent):
     _abstract = True
 
     # used for inheritance
-    _name = None
+    _name = None  #: Name of the component
+
+    #: Name or list of names of the component(s) to inherit from
     _inherit = None
 
-    # name of the collection to subscribe in
+    #: name of the collection to subscribe in
     _collection = None
 
-    # None means any Model, can be a list ['res.users', ...]
+    #: List of models on which the component can be applied.
+    #: None means any Model, can be a list ['res.users', ...]
     _apply_on = None
-    # component purpose ('import.mapper', ...)
+
+    #: Component purpose ('import.mapper', ...).
     _usage = None
 
     def __init__(self, work_context):

--- a/component_event/components/event.py
+++ b/component_event/components/event.py
@@ -122,6 +122,8 @@ try:
 except ImportError:
     _logger.debug("Cannot import 'cachetools'.")
 
+__all__ = ['skip_if']
+
 # Number of items we keep in LRU cache when we collect the events.
 # 1 item means: for an event name, model_name, collection, return
 # the event methods

--- a/connector/components/mapper.py
+++ b/connector/components/mapper.py
@@ -26,6 +26,14 @@ import collections
 _logger = logging.getLogger(__name__)
 
 
+__all__ = [
+    'Mapper', 'ImportMapper', 'ExportMapper', 'mapping',
+    'changed_by', 'only_create', 'none', 'convert',
+    'm2o_to_external', 'external_to_m2o', 'follow_m2o_relations',
+    'MapRecord', 'MapChild', 'ImportMapChild', 'ExportMapChild',
+]
+
+
 def mapping(func):
     """ Decorator, declare that a method is a mapping method.
 

--- a/connector/components/synchronizer.py
+++ b/connector/components/synchronizer.py
@@ -7,11 +7,13 @@
 Synchronizer
 ============
 
-A synchronizer orchestrates a synchronization with a backend.  It can be a
-record's import or export, a deletion of something, or anything else.  For
-instance, it will use the mappings to convert the data between both systems,
-the backend adapters to read or write data on the backend and the binders to
-create the link between them.
+A synchronizer orchestrates a synchronization with a backend. It's the actor
+who runs the flow and glues the logic of an import or export (or else).
+It uses other components for specialized tasks.
+
+For instance, it will use the mappings to convert the data between both
+systems, the backend adapters to read or write data on the backend and the
+binders to create the link between them.
 
 """
 
@@ -24,7 +26,10 @@ class Synchronizer(AbstractComponent):
     _name = 'base.synchronizer'
     _inherit = 'base.connector'
 
+    #: usage of the component used as mapper, can be customized in sub-classes
     _base_mapper_usage = 'mapper'
+    #: usage of the component used as backend adapter,
+    #: can be customized in sub-classes
     _base_backend_adapter_usage = 'backend.adapter'
 
     def __init__(self, work_context):
@@ -92,6 +97,7 @@ class Exporter(AbstractComponent):
     _name = 'base.exporter'
     _inherit = 'base.synchronizer'
     _usage = 'exporter'
+    #: usage of the component used as mapper, can be customized in sub-classes
     _base_mapper_usage = 'export.mapper'
 
 
@@ -101,6 +107,7 @@ class Importer(AbstractComponent):
     _name = 'base.importer'
     _inherit = 'base.synchronizer'
     _usage = 'importer'
+    #: usage of the component used as mapper, can be customized in sub-classes
     _base_mapper_usage = 'import.mapper'
 
 
@@ -109,4 +116,5 @@ class Deleter(AbstractComponent):
 
     _name = 'base.deleter'
     _inherit = 'base.synchronizer'
+    #: usage of the component used as mapper, can be customized in sub-classes
     _usage = 'deleter'

--- a/connector/doc/api/api_backend.rst
+++ b/connector/doc/api/api_backend.rst
@@ -21,6 +21,4 @@ Binding Model
 *************
 
 .. autoclass:: connector.models.backend_model.ExternalBinding
-   :members:
-   :undoc-members:
    :show-inheritance:

--- a/connector/doc/api/api_backend.rst
+++ b/connector/doc/api/api_backend.rst
@@ -9,7 +9,7 @@ Backend Model
 *************
 
 
-.. autoclass:: connector.backend_model.ConnectorBackend
+.. autoclass:: connector.models.backend_model.ConnectorBackend
    :members:
    :undoc-members:
    :show-inheritance:
@@ -20,7 +20,7 @@ Backend Model
 Binding Model
 *************
 
-.. autoclass:: connector.backend_model.ExternalBinding
+.. autoclass:: connector.models.backend_model.ExternalBinding
    :members:
    :undoc-members:
    :show-inheritance:

--- a/connector/doc/api/api_components.rst
+++ b/connector/doc/api/api_components.rst
@@ -16,6 +16,7 @@ Core Components
 .. automodule:: connector.components.core
    :members:
    :undoc-members:
+   :exclude-members: _module
    :show-inheritance:
    :private-members:
 
@@ -27,31 +28,98 @@ Connector Components
 .. automodule:: connector.components.binder
    :members:
    :undoc-members:
+   :exclude-members: _module
    :show-inheritance:
    :private-members:
 
 .. automodule:: connector.components.mapper
    :members:
-   :undoc-members:
+   :member-order: groupwise
+   :exclude-members: MappingDefinition, Mapper, ImportMapper, ExportMapper, MapChild, ImportMapChild, ExportMapChild
    :show-inheritance:
-   :private-members:
+
+   .. autoclass:: Mapper
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: ImportMapper
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: ExportMapper
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: MapChild
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: ImportMapChild
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: ExportMapChild
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
 
 .. automodule:: connector.components.backend_adapter
    :members:
-   :undoc-members:
    :show-inheritance:
-   :private-members:
+   :exclude-members: BackendAdapter, CRUDAdapter
+
+   .. autoclass:: BackendAdapter
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
+
+   .. autoclass:: CRUDAdapter
+      :members:
+      :show-inheritance:
+
+      .. autoattribute:: _name
+      .. autoattribute:: _inherit
+      .. autoattribute:: _usage
 
 .. automodule:: connector.components.synchronizer
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: _module
    :private-members:
 
 .. automodule:: connector.components.listener
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: _module
    :private-members:
 
 

--- a/connector/doc/api/api_event.rst
+++ b/connector/doc/api/api_event.rst
@@ -13,7 +13,6 @@ Components
 
 .. automodule:: odoo.addons.component_event.components.event
    :members:
-   :undoc-members:
    :show-inheritance:
 
 
@@ -22,16 +21,6 @@ Odoo Models Extensions
 **********************
 
 .. automodule:: odoo.addons.component_event.models.base
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-
-*********
-Internals
-*********
-
-.. automodule:: odoo.addons.component_event.core
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   .. autoclass:: Base
+      :show-inheritance:

--- a/connector/doc/api/api_queue.rst
+++ b/connector/doc/api/api_queue.rst
@@ -4,16 +4,6 @@
 Queue
 #####
 
-***
-Job
-***
-
-.. automodule:: odoo.addons.queue_job.job
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-******
 Models
 ******
 
@@ -23,6 +13,33 @@ Models
    :show-inheritance:
 
 .. automodule:: odoo.addons.queue_job.models.queue_job
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+   .. autoclass:: QueueJob
+
+     .. autoattribute:: _name
+     .. autoattribute:: _inherit
+
+***
+Job
+***
+
+.. automodule:: odoo.addons.queue_job.job
+
+   Decorators
+   ==========
+
+   .. autofunction:: job
+   .. autofunction:: related_action
+
+   Internals
+   =========
+
+   .. autoclass:: DelayableRecordset
+      :members:
+      :undoc-members:
+      :show-inheritance:
+
+   .. autoclass:: Job
+      :members:
+      :undoc-members:
+      :show-inheritance:

--- a/connector/doc/locale/fr/LC_MESSAGES/api.po
+++ b/connector/doc/locale/fr/LC_MESSAGES/api.po
@@ -30,7 +30,7 @@ msgid ""
 "Each connector will also create a ``connector.backend`` which allows the "
 "users to register their backends. For instance, the Magento connector has "
 "``magento.backend`` (``_inherit`` "
-":py:class:`connector.backend_model.connector_backend`).  This model contains"
+":py:class:`connector.models.backend_model.connector_backend`).  This model contains"
 " a ``version`` field which should have the same list of versions (with the "
 "exact same name) than the instances of "
 ":py:class:`~connector.backend.Backend`."
@@ -38,7 +38,7 @@ msgstr ""
 "Chaque connecteur va aussi créer un ``connector.backend`` qui permet aux "
 "utilisateurs d'inscrire leurs backends. Par exemple le connecteur Magento a "
 "un ``magento.backend`` (``_inherit`` "
-":py:class:`connector.backend_model.connector_backend`).  Ce modèle contient "
+":py:class:`connector.models.backend_model.connector_backend`).  Ce modèle contient "
 "un champ ``version`` qui doit avoir la même lists de versions (avec "
 "exactement le même nom) que les instances de "
 ":py:class:`~connector.backend.Backend`."
@@ -291,19 +291,19 @@ msgid "Backend Models"
 msgstr "Modèles du backend"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend:1
+#: connector.models.backend_model.ConnectorBackend:1
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:1
+#: connector.models.backend_model.ExternalBinding:1
 msgid "Bases: :class:`odoo.models.AbstractModel`"
 msgstr "Bases : :class:`odoo.models.AbstractModel`"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend:1
+#: connector.models.backend_model.ConnectorBackend:1
 msgid "An instance of an external backend to synchronize with."
 msgstr "Une instance d'un backend externe auquel se synchroniser"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend:3
+#: connector.models.backend_model.ConnectorBackend:3
 msgid ""
 "The backends have to ``_inherit`` this model in the connectors modules."
 msgstr ""
@@ -311,7 +311,7 @@ msgstr ""
 "connecteurs."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.get_backend:1
+#: connector.models.backend_model.ConnectorBackend.get_backend:1
 msgid ""
 "For a record of backend, returns the appropriate instance of "
 ":py:class:`~connector.backend.Backend`."
@@ -320,7 +320,7 @@ msgstr ""
 ":py:class:`~connector.backend.Backend`."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.name:1
+#: connector.models.backend_model.ConnectorBackend.name:1
 #: ../../../queue/model.pydocstring of
 #: connector.queue.model.QueueJob.func_string:1
 #: ../../../queue/model.pydocstring of
@@ -338,7 +338,7 @@ msgstr ""
 "habituellement affiché comme ligne unique dans les clients"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.name:4
+#: connector.models.backend_model.ConnectorBackend.name:4
 #: ../../../queue/model.pydocstring of
 #: connector.queue.model.QueueJob.func_string:4
 #: ../../../queue/model.pydocstring of
@@ -352,7 +352,7 @@ msgid "the maximum size of values stored for that field"
 msgstr "la taille maximum des valeurs stockées dans ce champ"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.name:5
+#: connector.models.backend_model.ConnectorBackend.name:5
 #: ../../../queue/model.pydocstring of
 #: connector.queue.model.QueueJob.func_string:5
 #: ../../../queue/model.pydocstring of
@@ -366,7 +366,7 @@ msgid "whether the values of this field can be translated"
 msgstr "si les valeurs de ce champ peuvent être traduites"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.version:1
+#: connector.models.backend_model.ConnectorBackend.version:1
 #: ../../../queue/model.pydocstring of connector.queue.model.QueueJob.state:1
 msgid ""
 "specifies the possible values for this field. It is given as either a list "
@@ -377,7 +377,7 @@ msgstr ""
 " méthode."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.version:4
+#: connector.models.backend_model.ConnectorBackend.version:4
 #: ../../../queue/model.pydocstring of connector.queue.model.QueueJob.state:4
 msgid ""
 "provides an extension of the selection in the case of an overridden field. "
@@ -387,7 +387,7 @@ msgstr ""
 "C'est une liste de paires (`value`, `string`)."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ConnectorBackend.version:7
+#: connector.models.backend_model.ConnectorBackend.version:7
 #: ../../../queue/model.pydocstring of connector.queue.model.QueueJob.state:7
 msgid ""
 "The attribute `selection` is mandatory except in the case of :ref:`related "
@@ -399,12 +399,12 @@ msgstr ""
 "definition>`."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:1
+#: connector.models.backend_model.ExternalBinding:1
 msgid "An abstract model for bindings to external records."
 msgstr "Un modèle abstrait pour une liaison à des enregistrements externes"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:3
+#: connector.models.backend_model.ExternalBinding:3
 msgid ""
 "An external binding is a binding between a backend and Odoo.  For "
 "example, for a partner, it could be ``magento.res.partner`` or for a "
@@ -415,7 +415,7 @@ msgstr ""
 "article, ``magento.product``."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:7
+#: connector.models.backend_model.ExternalBinding:7
 msgid ""
 "The final model, will be an ``_inherits`` of the Odoo model and will "
 "``_inherit`` this model."
@@ -424,7 +424,7 @@ msgstr ""
 "ce modèle."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:10
+#: connector.models.backend_model.ExternalBinding:10
 msgid ""
 "It will have a relation to the record (via ``_inherits``) and to the "
 "concrete backend model (``magento.backend`` for instance)."
@@ -433,7 +433,7 @@ msgstr ""
 "modèle backend concret (par exemple ``magento.backend``)."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:13
+#: connector.models.backend_model.ExternalBinding:13
 msgid ""
 "It will also contains all the data relative to the backend for the record."
 msgstr ""
@@ -441,52 +441,52 @@ msgstr ""
 "l'enregistrement."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:16
+#: connector.models.backend_model.ExternalBinding:16
 msgid "It needs to implements at least these fields:"
 msgstr "Il nécessite d'implémenter au moins ces champs :"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:18
+#: connector.models.backend_model.ExternalBinding:18
 msgid "odoo_id"
 msgstr "odoo_id"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:20
+#: connector.models.backend_model.ExternalBinding:20
 msgid "The many2one to the record it links (used by ``_inherits``)."
 msgstr "Le many2one vers l'enregistrement lié (utilisé par ``_inherits``)."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:22
+#: connector.models.backend_model.ExternalBinding:22
 msgid "backend_id"
 msgstr "backend_id"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:24
+#: connector.models.backend_model.ExternalBinding:24
 msgid "The many2one to the backend (for instance ``magento.backend``)."
 msgstr "Le many2one vers le backend (par exemple ``magento.backend``)."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:26
+#: connector.models.backend_model.ExternalBinding:26
 msgid "magento_id or prestashop_id or ..."
 msgstr "magento_id ou prestashop_id ou ..."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:28
+#: connector.models.backend_model.ExternalBinding:28
 msgid "The ID on the backend."
 msgstr "L'ID sur le backend."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:30
+#: connector.models.backend_model.ExternalBinding:30
 msgid "sync_date"
 msgstr "sync_date"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:32
+#: connector.models.backend_model.ExternalBinding:32
 msgid "Last date of synchronization"
 msgstr "Dernière date de synchronisation"
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:35
+#: connector.models.backend_model.ExternalBinding:35
 msgid ""
 "The definition of the relations in ``_columns`` is to be done in the "
 "concrete classes because the relations themselves do not exist in this "
@@ -497,7 +497,7 @@ msgstr ""
 " module."
 
 #: ../../../backend_model.pydocstring of
-#: connector.backend_model.ExternalBinding:39
+#: connector.models.backend_model.ExternalBinding:39
 msgid ""
 "For example, for a ``res.partner.category`` from Magento, I would have (this"
 " is a consolidation of all the columns from the abstract models, in "

--- a/connector/doc/locale/fr/LC_MESSAGES/guides.po
+++ b/connector/doc/locale/fr/LC_MESSAGES/guides.po
@@ -606,10 +606,10 @@ msgstr ""
 #: ../../guides/concepts.rst:112
 msgid ""
 "It is always accompanied by a concrete subclass of the model :py:class:"
-"`~connector.backend_model.connector_backend`."
+"`~connector.models.backend_model.connector_backend`."
 msgstr ""
 "Il est toujours accompagné d'une sous-classe concrète du modèle :py:class:"
-"`~connector.backend_model.connector_backend`."
+"`~connector.models.backend_model.connector_backend`."
 
 #: ../../guides/concepts.rst:117
 msgid "Declare the backends (see :py:class:`connector.backend.Backend`)"
@@ -650,12 +650,12 @@ msgstr ""
 #: ../../guides/concepts.rst:130
 msgid ""
 "It contains a :py:class:`~connector.backend.Backend`, a record of a concrete "
-"subclass of the model :py:class:`~connector.backend_model."
+"subclass of the model :py:class:`~connector.models.backend_model."
 "connector_backend`, a :py:class:`~connector.session.Session` and the name of "
 "the model to work with."
 msgstr ""
 "Il contient un :py:class:`~connector.backend.Backend`, un enregistrement "
-"d'une sous-classe concrète du modèle :py:class:`~connector.backend_model."
+"d'une sous-classe concrète du modèle :py:class:`~connector.models.backend_model."
 "connector_backend`, une :py:class:`~connector.session.Session` et le nom du "
 "modèle avec lequel travailler."
 


### PR DESCRIPTION
Fix the build of `master` which was due to a long-standing issue in the docs generation (recursion error).

* Sphinx crashes with a recursion error when trying to document Models
fields. Remove the fields from the documentation altogether, they didn't
bring much value anyway
* Went through all the API pages and removed many useless autodoc with a
mix of __all__, :exclude-members: or by defining more precisely what we
want with :autoclass:, :autoatttribute:, ... or simply removing them
* Changed the order of a few autodocs by putting the most useful
classes/functions first
* Improved a few docstrings
* Fix connector docs dotted path to models