### PR TITLE
[FIX] Prevent two jobrunners from being active on the same database

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -117,6 +117,7 @@ import logging
 import os
 import re
 import select
+import signal
 import threading
 import time
 
@@ -199,6 +200,15 @@ class Database(object):
         self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         self.has_connector = self._has_connector()
         if self.has_connector:
+            if not self._lock():
+                _logger.exception(
+                    "Jobrunner lock was not granted. Is there another "
+                    "jobrunner active in database %s? Trying to stop Odoo.",
+                    self.db_name)
+                os.kill(openerp.service.server.server.pid, signal.SIGINT)
+                raise RuntimeError(
+                    'Jobrunner lock was not granted in database %s' % db_name)
+
             self.has_channel = self._has_queue_job_column('channel')
             self._initialize()
 
@@ -222,6 +232,14 @@ class Database(object):
                 else:
                     raise
             return cr.fetchone()
+
+    def _lock(self):
+        """ Request a session lock on the database. The session lock will be
+        released when self.conn is deleted. If the lock is not granted, there
+        is already a jobrunner running in this database. """
+        with closing(self.conn.cursor()) as cr:
+            cr.execute("select pg_try_advisory_lock(hashtext('jobrunner'))")
+            return cr.fetchone()[0]
 
     def _has_queue_job_column(self, column):
         if not self.has_connector:


### PR DESCRIPTION
a the same time. Stop the Odoo server if this is detected, as it implies that Odoo itself
is already running.

Running multiple jobrunners causes concurrent transaction errors in the
postgresql database. If the job concerns communication with an outside system,
the same jobs are being run indefinitely, causing integrity problems between
Odoo and the external system if the external method is not reentrant.