### PR TITLE
[FIX] Get a session with a database

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -68,18 +68,6 @@ class RunJobController(http.Controller):
             self.job_storage_class(session).store(job)
         _logger.debug('%s done', job)
 
-    @http.route('/connector/session', type='http', auth="none")
-    def session(self):
-        """ Used by the jobrunner to spawn a session
-
-        The connector jobrunner uses anonymous sessions when it calls
-        ``/connnector/runjob``.  To avoid having thousands of anonymous
-        sessions, before running jobs, it creates a ``requests.Session``
-        and does a GET on ``/connector/session``, providing it a cookie
-        which will be used for subsequent calls to runjob.
-        """
-        return ''
-
     @http.route('/connector/runjob', type='http', auth='none')
     def runjob(self, db, job_uuid, **kw):
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -146,7 +146,7 @@ ERROR_RECOVERY_DELAY = 5
 _logger = logging.getLogger(__name__)
 
 
-session = requests.Session()
+sessions = {}
 
 
 # Unfortunately, it is not possible to extend the Odoo
@@ -192,10 +192,13 @@ def _connection_info_for(db_name):
 
 def _async_http_get(scheme, host, port, user, password, db_name, job_uuid):
 
+    if db_name not in sessions:
+        sessions[db_name] = requests.Session()
+    session = sessions[db_name]
     if not session.cookies:
         # obtain an anonymous session
         _logger.info("obtaining an anonymous session for the job runner")
-        url = ('%s://%s:%s/connector/session' % (scheme, host, port))
+        url = ('%s://%s:%s/web/login?db=%s' % (scheme, host, port, db_name))
         auth = None
         if user:
             auth = (user, password)


### PR DESCRIPTION
If a job is executed using a session without a database, Odoo will always connect to the postgreql database for a database list. This is actually expensive because Odoo does not reuse the psycopg2 connection to the postgresql database so every job that is being run leads to a new database connection that is only used once for nothing.