### PR TITLE
Fix/8.0/session with database

### DIFF
--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -68,18 +68,6 @@ class RunJobController(http.Controller):
             self.job_storage_class(session).store(job)
         _logger.debug('%s done', job)
 
-    @http.route('/connector/session', type='http', auth="none")
-    def session(self):
-        """ Used by the jobrunner to spawn a session
-
-        The connector jobrunner uses anonymous sessions when it calls
-        ``/connnector/runjob``.  To avoid having thousands of anonymous
-        sessions, before running jobs, it creates a ``requests.Session``
-        and does a GET on ``/connector/session``, providing it a cookie
-        which will be used for subsequent calls to runjob.
-        """
-        return ''
-
     @http.route('/connector/runjob', type='http', auth='none')
     def runjob(self, db, job_uuid, **kw):
 

--- a/connector/controllers/main.py
+++ b/connector/controllers/main.py
@@ -68,6 +68,18 @@ class RunJobController(http.Controller):
             self.job_storage_class(session).store(job)
         _logger.debug('%s done', job)
 
+    @http.route('/connector/session', type='http', auth="none")
+    def session(self):
+        """ Used by the jobrunner to spawn a session
+
+        The connector jobrunner uses anonymous sessions when it calls
+        ``/connnector/runjob``.  To avoid having thousands of anonymous
+        sessions, before running jobs, it creates a ``requests.Session``
+        and does a GET on ``/connector/session``, providing it a cookie
+        which will be used for subsequent calls to runjob.
+        """
+        return ''
+
     @http.route('/connector/runjob', type='http', auth='none')
     def runjob(self, db, job_uuid, **kw):
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -134,8 +134,7 @@ ERROR_RECOVERY_DELAY = 5
 
 _logger = logging.getLogger(__name__)
 
-
-session = requests.Session()
+sessions = {}
 
 
 # Unfortunately, it is not possible to extend the Odoo
@@ -157,12 +156,13 @@ def _channels():
 
 
 def _async_http_get(port, db_name, job_uuid):
-
+    if not sessions.get(db_name):
+        sessions[db_name] = requests.Session()
+    session = sessions[db_name]
     if not session.cookies:
         # obtain an anonymous session
         _logger.info("obtaining an anonymous session for the job runner")
-        url = ('http://localhost:%s/connector/session' %
-               (port, db_name, job_uuid))
+        url = 'http://localhost:%s/web/login?db=%s' % (port, db_name)
         response = session.get(url, timeout=30)
         response.raise_for_status()
 

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -135,6 +135,9 @@ ERROR_RECOVERY_DELAY = 5
 _logger = logging.getLogger(__name__)
 
 
+session = requests.Session()
+
+
 # Unfortunately, it is not possible to extend the Odoo
 # server command line arguments, so we resort to environment variables
 # to configure the runner (channels mostly).
@@ -153,10 +156,16 @@ def _channels():
     )
 
 
-session = requests.Session()
-
-
 def _async_http_get(port, db_name, job_uuid):
+
+    if not session.cookies:
+        # obtain an anonymous session
+        _logger.info("obtaining an anonymous session for the job runner")
+        url = ('http://localhost:%s/connector/session' %
+               (port, db_name, job_uuid))
+        response = session.get(url, timeout=30)
+        response.raise_for_status()
+
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
     def set_job_pending():
@@ -188,6 +197,7 @@ def _async_http_get(port, db_name, job_uuid):
             set_job_pending()
         except:
             _logger.exception("exception in GET %s", url)
+            session.cookies.clear()
             set_job_pending()
     thread = threading.Thread(target=urlopen)
     thread.daemon = True

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -153,6 +153,9 @@ def _channels():
     )
 
 
+session = requests.Session()
+
+
 def _async_http_get(port, db_name, job_uuid):
     # Method to set failed job (due to timeout, etc) as pending,
     # to avoid keeping it as enqueued.
@@ -175,7 +178,7 @@ def _async_http_get(port, db_name, job_uuid):
         try:
             # we are not interested in the result, so we set a short timeout
             # but not too short so we trap and log hard configuration errors
-            response = requests.get(url, timeout=1)
+            response = session.get(url, timeout=1)
 
             # raise_for_status will result in either nothing, a Client Error
             # for HTTP Response codes between 400 and 500 or a Server Error


### PR DESCRIPTION
Backport of Guewen's session mechanism from 9.0 with my modification from #300.

If a job is executed using a session without a database, Odoo will always connect to the postgreql database for a database list. This is actually expensive because Odoo does not reuse the psycopg2 connection to the postgresql database so every job that is being run leads to a new database connection that is only used once for nothing.