### PR TITLE
[10.0][FIX] Fix component lookup when no result based on the collection

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -378,6 +378,7 @@ class WorkContext(object):
         component_classes = self._lookup_components(
             usage=usage, model_name=model_name
         )
+        save_component_classes = component_classes
         if not component_classes:
             raise NoComponentError(
                 "No component found for collection '%s', "
@@ -390,6 +391,10 @@ class WorkContext(object):
             component_classes = [
                 c for c in component_classes
                 if c._collection == self.collection._name]
+        # If the previous match (based on collection) remove every components,
+        # we have to restore it because maybe the filter based on
+        # apply_models could match
+        component_classes = component_classes or save_component_classes
         if len(component_classes) > 1:
             # ... or try to find the one specifically linked to the model
             component_classes = [

--- a/component/tests/test_component.py
+++ b/component/tests/test_component.py
@@ -41,10 +41,23 @@ class TestComponent(TransactionComponentRegistryCase):
             _usage = 'for.test'
             _apply_on = ['res.users']
 
+        class ComponentCompanyBase(Component):
+            _name = 'component.company.base'
+            _usage = 'test.mapper'
+
+        class ComponentCompany(Component):
+            # Do not specify a collection
+            _name = 'component.company'
+            _inherit = 'component.company.base'
+            _apply_on = ['res.company']
+            _usage = 'test.mapper'
+
         # build the components and register them in our
         # test component registry
         Component1._build_component(self.comp_registry)
         Component2._build_component(self.comp_registry)
+        ComponentCompanyBase._build_component(self.comp_registry)
+        ComponentCompany._build_component(self.comp_registry)
 
         # our collection, in a less abstract use case, it
         # could be a record of 'magento.backend' for instance
@@ -106,6 +119,17 @@ class TestComponent(TransactionComponentRegistryCase):
             self.assertNotEquals(base.work, comp.work)
             self.assertEquals('res.partner', base.work.model_name)
             self.assertEquals('res.users', comp.work.model_name)
+
+    def test_without_collection(self):
+        """
+        For 2 candidate Components without collection, one without _apply_on
+        and another one with, the component with a matching model
+        must be returned
+        :return:
+        """
+        with self.collection_record.work_on(
+                'res.company', components_registry=self.comp_registry) as work:
+            self.assertTrue(bool(work.component(usage='test.mapper')))
 
     def test_component_get_by_name_wrong_model(self):
         """ Use component_by_name with a model not in _apply_on """


### PR DESCRIPTION
**Context**
To create my new `Component` (a json export mapper for my case), I only specify a `_apply_on` and `_usage` (also `_name` and `_inherit` of course).
**Bug**
If I don't specify a `_collection`, my component is ignored.
**Expected behaviour**
If no `_collection` specified on the component, it's because it could be apply for every collections (for models in `_apply_on`)