### PR TITLE
[FIX] When running tests, preserve backends already loaded

### DIFF
--- a/connector/tests/test_backend.py
+++ b/connector/tests/test_backend.py
@@ -19,11 +19,13 @@ class test_backend(unittest2.TestCase):
 
     def setUp(self):
         super(test_backend, self).setUp()
+        BACKENDS._backends = BACKENDS.backends
+        BACKENDS.backends = set()
         self.service = 'calamitorium'
 
     def tearDown(self):
         super(test_backend, self).tearDown()
-        BACKENDS.backends.clear()
+        BACKENDS.backends = BACKENDS._backends
 
     def test_new_backend(self):
         """ Create a backend"""
@@ -77,6 +79,8 @@ class test_backend_register(common.TransactionCase):
 
     def setUp(self):
         super(test_backend_register, self).setUp()
+        BACKENDS._backends = BACKENDS.backends
+        BACKENDS.backends = set()
         self.service = 'calamitorium'
         self.version = '1.14'
         self.parent = Backend(self.service)
@@ -86,7 +90,7 @@ class test_backend_register(common.TransactionCase):
 
     def tearDown(self):
         super(test_backend_register, self).tearDown()
-        BACKENDS.backends.clear()
+        BACKENDS.backends = BACKENDS._backends
         del self.backend._class_entries[:]
 
     def test_register_class(self):

--- a/connector/tests/test_producer.py
+++ b/connector/tests/test_producer.py
@@ -70,7 +70,11 @@ class test_producers(common.TransactionCase):
         the event should not be fired at all
         """
         # clear all the registered events
+        consumers = on_record_write._consumers
         on_record_write._consumers = {None: set()}
-        with mock.patch.object(on_record_write, 'fire'):
-            self.partner.write({'name': 'Kif Kroker'})
-            self.assertEqual(on_record_write.fire.called, False)
+        try:
+            with mock.patch.object(on_record_write, 'fire'):
+                self.partner.write({'name': 'Kif Kroker'})
+                self.assertEqual(on_record_write.fire.called, False)
+        finally:
+            on_record_write._consumers = consumers


### PR DESCRIPTION
This prevents "ValueError: No backend found for magento 1.7"
when running tests on connector and magentoerpconnect in one go.