### PR TITLE
[12.0][FIX] component, component_event: tag unittest.TestCase subclasses

### DIFF
--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -99,7 +99,8 @@ class SavepointComponentCase(common.SavepointCase, ComponentMixin):
         ComponentMixin.setUp(self)
 
 
-class ComponentRegistryCase(unittest.TestCase):
+class ComponentRegistryCase(
+        unittest.TestCase, common.MetaCase('DummyCase', (object,), {})):
     """ This test case can be used as a base for writings tests on components
 
     This test case is meant to test components in a special component registry,

--- a/component_event/tests/test_event.py
+++ b/component_event/tests/test_event.py
@@ -12,8 +12,10 @@ from odoo.addons.component.tests.common import (
 from odoo.addons.component.core import Component
 from odoo.addons.component_event.core import EventWorkContext
 from odoo.addons.component_event.components.event import skip_if
+from odoo.tests.common import tagged
 
 
+@tagged('standard', 'at_install')
 class TestEventWorkContext(unittest.TestCase):
     """ Test Events Components """
 


### PR DESCRIPTION
Since [v12.0](https://github.com/odoo/odoo/commit/b356b190338e3ee032b9e3a7f670f76468965006), direct subclasses of `unittest.TestCase` which do not have :class:`odoo.tests.common.MetaCase` as a meta-class must be explicitly tagged with :method:`odoo.tests.common.tagged`, otherwise they will not be picked up by the test runner. E.g.:

```python
@tagged('standard', 'at_install')
```
