### PR TITLE
[12.0][Connector] Make connector checkpoint compatible in multi company environment

### DIFF
--- a/connector/__manifest__.py
+++ b/connector/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 {'name': 'Connector',
- 'version': '12.0.1.0.0',
+ 'version': '12.0.1.1.0',
  'author': 'Camptocamp,Openerp Connector Core Editors,'
            'Odoo Community Association (OCA)',
  'website': 'http://odoo-connector.com',

--- a/connector/migrations/12.0.1.1.0/end-migration.py
+++ b/connector/migrations/12.0.1.1.0/end-migration.py
@@ -1,0 +1,15 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Now that everything has been loaded, compute the value of
+    channel_method_name.
+    """
+
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    checkpoints = env['connector.checkpoint'].search([])
+    checkpoints._compute_company()

--- a/connector/migrations/12.0.1.1.0/pre-migration.py
+++ b/connector/migrations/12.0.1.1.0/pre-migration.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute("""
+        ALTER TABLE connector_checkpoint
+        ADD COLUMN company_id integer
+    """)

--- a/connector/models/checkpoint.py
+++ b/connector/models/checkpoint.py
@@ -62,6 +62,12 @@ class ConnectorCheckpoint(models.Model):
             return [('id', '=', '0')]
         return [('id', 'in', tuple(ids))]
 
+    @api.depends('backend_id')
+    def _compute_company(self):
+        for check in self:
+            if hasattr(check.backend_id, 'company_id'):
+                check.company_id = check.backend_id.company_id.id
+
     record = fields.Reference(
         compute='_compute_record',
         selection='_reference_models',
@@ -98,6 +104,12 @@ class ConnectorCheckpoint(models.Model):
         readonly=True,
         default='need_review',
     )
+    company_id = fields.Many2one(
+        'res.company',
+        string="Company",
+        readonly=True,
+        compute='_compute_company',
+        store=True)
 
     @api.multi
     def reviewed(self):

--- a/connector/security/connector_security.xml
+++ b/connector/security/connector_security.xml
@@ -16,4 +16,11 @@
         <field name="implied_ids" eval="[(4, ref('group_connector_manager'))]"/>
     </record>
 
+    <record id="connector_checkpoint_multicompany_rule" model="ir.rule">
+        <field name="name">Connector Checkpoint multi-company</field>
+        <field name="model_id" ref="model_connector_checkpoint"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force"> ['|','|',('company_id.child_ids','child_of',[user.company_id.id]),('company_id','child_of',[user.company_id.id]),('company_id','=',False)]</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
I have some right access errors on multi company environment. As there is no company_id on `connector_checkpoint`, when company A sees checkpoint that should belong to company B, I have some access error on linked records (from field `backend_id` field for instance).

I had to do a migration script because when updating the module and creating the new computed company_id field, the backends models are not loaded yet and Odoo can't find it in registry.

@guewen 

