### PR TITLE
Fix compatibility with cachetools 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cachetools>=2.0.1,<3.0.0
+cachetools>=2.0.1
 

--- a/setup/component/setup.py
+++ b/setup/component/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     odoo_addons={
         'external_dependencies_override': {
             'python': {
-                'cachetools': 'cachetools>=2.0.1,<3.0.0',
+                'cachetools': 'cachetools>=2.0.1',
             }
         }
     }


### PR DESCRIPTION
Forward port of https://github.com/OCA/connector/pull/331

It doesn't allow anymore to refer to 'self' in the key.
Add an indirection level using another method that takes
the cached arguments.

See discussion on https://github.com/tkem/cachetools/issues/107