### PR TITLE
[FIX] Define model as property on work context

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -238,7 +238,6 @@ class WorkContext(object):
                  components_registry=None, **kwargs):
         self.collection = collection
         self.model_name = model_name
-        self.model = self.env[model_name]
         # lookup components in an alternative registry, used by the tests
         if components_registry is not None:
             self.components_registry = components_registry
@@ -269,6 +268,14 @@ class WorkContext(object):
         This is the environment of the current collection.
         """
         return self.collection.env
+
+    @property
+    def model(self):
+        """ Return the current Odoo model
+
+        This is the model of the current environment.
+        """
+        return self.env[self.model_name]
 
     def work_on(self, model_name=None, collection=None):
         """ Create a new work context for another model keeping attributes


### PR DESCRIPTION
To allow to change the context of model returned by work context,
we need to define model as property.

Like this, we can change the collection environment with new context,
and model will get from contexted environment.