### PR TITLE
Recover the v13 new feature of create method with a list of vals on Base

### DIFF
--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -94,12 +94,13 @@ class Base(models.AbstractModel):
         collecter = work._component_class_by_name("base.event.collecter")(work)
         return collecter.collect_events(name)
 
-    @api.model
-    def create(self, vals):
-        record = super(Base, self).create(vals)
-        fields = list(vals.keys())
-        self._event("on_record_create").notify(record, fields=fields)
-        return record
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super(Base, self).create(vals_list)
+        for idx, vals in enumerate(vals_list):
+            fields = list(vals.keys())
+            self._event("on_record_create").notify(records[idx], fields=fields)
+        return records
 
     def write(self, vals):
         result = super(Base, self).write(vals)


### PR DESCRIPTION
Currently, as soon as this module is installed, each loading of multiple records at a time is converted to  a loading of a single record at a time.
I changed the decorator to support vals_list in create