### PR TITLE
[FIX] connector: restore binder context

### DIFF
--- a/connector/components/binder.py
+++ b/connector/components/binder.py
@@ -48,6 +48,7 @@ class Binder(AbstractComponent):
                  or an empty recordset if the external_id is not mapped
         :rtype: recordset
         """
+        context = self.env.context
         bindings = self.model.with_context(active_test=False).search(
             [(self._external_field, '=', tools.ustr(external_id)),
              (self._backend_field, '=', self.backend_record.id)]
@@ -59,6 +60,7 @@ class Binder(AbstractComponent):
         bindings.ensure_one()
         if unwrap:
             bindings = bindings[self._odoo_field]
+        bindings = bindings.with_context(context)
         return bindings
 
     def to_external(self, binding, wrap=False):


### PR DESCRIPTION
When binder looks for a binding, search is performed indicating `active_test=False` in context, but found binding keeps this key in context affecting later operations.

For example, having an already imported sales order, an update operation is made to add a new line. When excepcions from `sale_exception` are tested, the ones that are disabled are also tested, because as `active_test=False` is in context they are found too.