### PR TITLE
[13.0]  component/component_event: allow registry propagation via context

### DIFF
--- a/component/models/collection.py
+++ b/component/models/collection.py
@@ -93,4 +93,9 @@ class Collection(models.AbstractModel):
 
         """
         self.ensure_one()
+        # Allow propagation of custom component registry via context
+        # TODO: maybe to be moved to `WorkContext.__init__`
+        components_registry = self.env.context.get("components_registry")
+        if components_registry:
+            kwargs["components_registry"] = components_registry
         yield WorkContext(model_name=model_name, collection=self, **kwargs)

--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -40,6 +40,10 @@ class ComponentMixin(object):
             # build the components of the current tested addon
             current_addon = _get_addon_name(cls.__module__)
             env["component.builder"].load_components(current_addon)
+            # share component registry everywhere
+            cls.env.context = dict(
+                cls.env.context, components_registry=cls._components_registry
+            )
 
     # pylint: disable=W8106
     def setUp(self):
@@ -174,6 +178,9 @@ class ComponentRegistryCase(
         # of the components. Here, we'll add components later in
         # the components registry, but we don't mind for the tests.
         self.comp_registry.ready = True
+        self.env.context = dict(
+            self.env.context, components_registry=self.comp_registry
+        )
 
     def tearDown(self):
         super().tearDown()

--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -147,28 +147,29 @@ class ComponentRegistryCase(
 
     """
 
-    def setUp(self):
-        super().setUp()
-
+    @staticmethod
+    def _setup_registry(class_or_instance):
         # keep the original classes registered by the metaclass
         # so we'll restore them at the end of the tests, it avoid
         # to pollute it with Stub / Test components
-        self._original_components = copy.deepcopy(MetaComponent._modules_components)
+        class_or_instance._original_components = copy.deepcopy(
+            MetaComponent._modules_components
+        )
 
         # it will be our temporary component registry for our test session
-        self.comp_registry = ComponentRegistry()
+        class_or_instance.comp_registry = ComponentRegistry()
 
         # it builds the 'final component' for every component of the
         # 'component' addon and push them in the component registry
-        self.comp_registry.load_components("component")
+        class_or_instance.comp_registry.load_components("component")
         # build the components of every installed addons already installed
         # but the current addon (when running with pytest/nosetest, we
         # simulate the --test-enable behavior by excluding the current addon
         # which is in 'to install' / 'to upgrade' with --test-enable).
-        current_addon = _get_addon_name(self.__module__)
+        current_addon = _get_addon_name(class_or_instance.__module__)
         with new_rollbacked_env() as env:
             env["component.builder"].build_registry(
-                self.comp_registry,
+                class_or_instance.comp_registry,
                 states=("installed",),
                 exclude_addons=[current_addon],
             )
@@ -177,15 +178,18 @@ class ComponentRegistryCase(
         # normally, it is set to True and the end of the build
         # of the components. Here, we'll add components later in
         # the components registry, but we don't mind for the tests.
-        self.comp_registry.ready = True
-        self.env.context = dict(
-            self.env.context, components_registry=self.comp_registry
-        )
+        class_or_instance.comp_registry.ready = True
+        if hasattr(class_or_instance, "env"):
+            # let it propagate via ctx
+            class_or_instance.env.context = dict(
+                class_or_instance.env.context,
+                components_registry=class_or_instance.comp_registry,
+            )
 
-    def tearDown(self):
-        super().tearDown()
+    @staticmethod
+    def _teardown_registry(class_or_instance):
         # restore the original metaclass' classes
-        MetaComponent._modules_components = self._original_components
+        MetaComponent._modules_components = class_or_instance._original_components
 
     def _load_module_components(self, module):
         self.comp_registry.load_components(module)
@@ -203,25 +207,27 @@ class TransactionComponentRegistryCase(common.TransactionCase, ComponentRegistry
         # resolve an inheritance issue (common.TransactionCase does not use
         # super)
         common.TransactionCase.setUp(self)
-        ComponentRegistryCase.setUp(self)
+        ComponentRegistryCase._setup_registry(self)
         self.collection = self.env["collection.base"]
 
-    def teardown(self):
+    def tearDown(self):
+        ComponentRegistryCase._teardown_registry(self)
         common.TransactionCase.tearDown(self)
-        ComponentRegistryCase.tearDown(self)
 
 
 class SavepointComponentRegistryCase(common.SavepointCase, ComponentRegistryCase):
     """ Adds Odoo Transaction with Savepoint in the base Component TestCase """
 
     # pylint: disable=W8106
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # resolve an inheritance issue (common.SavepointCase does not use
         # super)
-        common.SavepointCase.setUp(self)
-        ComponentRegistryCase.setUp(self)
-        self.collection = self.env["collection.base"]
+        common.SavepointCase.setUpClass()
+        ComponentRegistryCase._setup_registry(cls)
+        cls.collection = cls.env["collection.base"]
 
-    def teardown(self):
-        common.SavepointCase.tearDown(self)
-        ComponentRegistryCase.tearDown(self)
+    @classmethod
+    def tearDownClass(cls):
+        ComponentRegistryCase._teardown_registry(cls)
+        common.SavepointCase.tearDownClass()

--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -40,10 +40,10 @@ class ComponentMixin(object):
             # build the components of the current tested addon
             current_addon = _get_addon_name(cls.__module__)
             env["component.builder"].load_components(current_addon)
-            # share component registry everywhere
-            cls.env.context = dict(
-                cls.env.context, components_registry=cls._components_registry
-            )
+            if hasattr(cls, "env"):
+                cls.env.context = dict(
+                    cls.env.context, components_registry=cls._components_registry
+                )
 
     # pylint: disable=W8106
     def setUp(self):
@@ -76,6 +76,10 @@ class TransactionComponentCase(common.TransactionCase, ComponentMixin):
         # super)
         common.TransactionCase.setUp(self)
         ComponentMixin.setUp(self)
+        # There's no env on setUpClass of TransactionCase, must do it here.
+        self.env.context = dict(
+            self.env.context, components_registry=self._components_registry
+        )
 
 
 class SavepointComponentCase(common.SavepointCase, ComponentMixin):

--- a/component/tests/test_build_component.py
+++ b/component/tests/test_build_component.py
@@ -5,10 +5,10 @@ import mock
 
 from odoo.addons.component.core import AbstractComponent, Component
 
-from .common import ComponentRegistryCase
+from .common import TransactionComponentRegistryCase
 
 
-class TestBuildComponent(ComponentRegistryCase):
+class TestBuildComponent(TransactionComponentRegistryCase):
     """ Test build of components
 
     All the tests in this suite are based on the same principle with

--- a/component/tests/test_lookup.py
+++ b/component/tests/test_lookup.py
@@ -3,10 +3,10 @@
 
 from odoo.addons.component.core import AbstractComponent, Component
 
-from .common import ComponentRegistryCase
+from .common import TransactionComponentRegistryCase
 
 
-class TestLookup(ComponentRegistryCase):
+class TestLookup(TransactionComponentRegistryCase):
     """ Test the ComponentRegistry
 
     Tests in this testsuite mainly do:

--- a/component/tests/test_work_on.py
+++ b/component/tests/test_work_on.py
@@ -3,20 +3,16 @@
 
 from odoo.addons.component.core import ComponentRegistry, WorkContext
 
-from .common import TransactionComponentCase
+from .common import SavepointComponentRegistryCase
 
 
-class TestWorkOn(TransactionComponentCase):
+class TestWorkOn(SavepointComponentRegistryCase):
     """ Test on WorkContext
 
     This model is mostly a container, so we check the access
     to the attributes and properties.
 
     """
-
-    def setUp(self):
-        super().setUp()
-        self.collection = self.env["collection.base"]
 
     def test_collection_work_on(self):
         """ Create a new instance and test attributes access """

--- a/component/tests/test_work_on.py
+++ b/component/tests/test_work_on.py
@@ -24,6 +24,20 @@ class TestWorkOn(SavepointComponentRegistryCase):
             self.assertEqual(self.env["res.partner"], work.model)
             self.assertEqual(self.env, work.env)
 
+    def test_collection_work_on_registry_via_context(self):
+        """ Test propagation of registry via context """
+        registry = ComponentRegistry()
+        collection_record = self.collection.with_context(
+            components_registry=registry
+        ).new()
+        with collection_record.work_on("res.partner") as work:
+            self.assertEqual(collection_record, work.collection)
+            self.assertEqual("collection.base", work.collection._name)
+            self.assertEqual("res.partner", work.model_name)
+            self.assertEqual(self.env["res.partner"], work.model)
+            self.assertEqual(work.env, collection_record.env)
+            self.assertEqual(work.components_registry, registry)
+
     def test_propagate_work_on(self):
         """ Check custom attributes and their propagation """
         registry = ComponentRegistry()

--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -63,6 +63,9 @@ class Base(models.AbstractModel):
 
         """
         dbname = self.env.cr.dbname
+        components_registry = self.env.context.get(
+            "components_registry", components_registry
+        )
         comp_registry = components_registry or _component_databases.get(dbname)
         if not comp_registry or not comp_registry.ready:
             # No event should be triggered before the registry has been loaded

--- a/component_event/tests/test_event.py
+++ b/component_event/tests/test_event.py
@@ -135,6 +135,7 @@ class TestEvent(ComponentRegistryCase):
 
     def setUp(self):
         super(TestEvent, self).setUp()
+        ComponentRegistryCase._setup_registry(self)
         self._load_module_components("component_event")
 
         # get the collecter to notify the event

--- a/connector/tests/test_advisory_lock.py
+++ b/connector/tests/test_advisory_lock.py
@@ -8,12 +8,12 @@ from odoo.modules.registry import Registry
 from odoo.tests import common
 
 from odoo.addons.component.core import WorkContext
-from odoo.addons.component.tests.common import TransactionComponentCase
+from odoo.addons.component.tests.common import SavepointComponentCase
 from odoo.addons.connector.database import pg_try_advisory_lock
 from odoo.addons.queue_job.exception import RetryableJobError
 
 
-class TestAdvisoryLock(TransactionComponentCase):
+class TestAdvisoryLock(SavepointComponentCase):
     def setUp(self):
         super(TestAdvisoryLock, self).setUp()
         self.registry2 = Registry(common.get_db_name())

--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -25,7 +25,12 @@ from odoo.addons.connector.components.mapper import (
 class TestMapper(ComponentRegistryCase):
     def setUp(self):
         super(TestMapper, self).setUp()
+        ComponentRegistryCase._setup_registry(self)
         self.comp_registry.load_components("connector")
+
+    def tearDown(self):
+        ComponentRegistryCase._teardown_registry(self)
+        super(TestMapper, self).tearDown()
 
     def test_mapping_decorator(self):
         class KifKrokerMapper(Component):


### PR DESCRIPTION
Makes easier to share components across modules (especially in tests).