### PR TITLE
[12.0] Recover the new feature of create method with a list of vals on Base

### DIFF
--- a/component/__manifest__.py
+++ b/component/__manifest__.py
@@ -17,6 +17,6 @@
      'python': ['cachetools'],
  },
  'installable': True,
- 'development_status': 'Stable',
+ 'development_status': 'Production/Stable',
  'maintainers': ['guewen'],
  }

--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -90,12 +90,13 @@ class Base(models.AbstractModel):
         collecter = work._component_class_by_name('base.event.collecter')(work)
         return collecter.collect_events(name)
 
-    @api.model
-    def create(self, vals):
-        record = super(Base, self).create(vals)
-        fields = list(vals.keys())
-        self._event('on_record_create').notify(record, fields=fields)
-        return record
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super(Base, self).create(vals_list)
+        for idx, vals in enumerate(vals_list):
+            fields = list(vals.keys())
+            self._event("on_record_create").notify(records[idx], fields=fields)
+        return records
 
     @api.multi
     def write(self, vals):

--- a/connector/components/synchronizer.py
+++ b/connector/components/synchronizer.py
@@ -161,7 +161,7 @@ class GenericExporter(AbstractComponent):
         # The commit will also release the lock acquired on the binding
         # record
         if not odoo.tools.config['test_enable']:
-            self.env.cr.commit()  # noqa
+            self.env.cr.commit()  # pylint: disable=E8102
 
         self._after_export()
         return result
@@ -349,7 +349,7 @@ class GenericExporter(AbstractComponent):
                     # the same binding. It will be caught and
                     # raise a RetryableJobError.
                     if not odoo.tools.config['test_enable']:
-                        self.env.cr.commit()  # noqa
+                        self.env.cr.commit()  # pylint: disable=E8102
         else:
             # If my_backend_bind_ids does not exist we are typically in a
             # "direct" binding (the binding record is the same record).

--- a/test_component/__manifest__.py
+++ b/test_component/__manifest__.py
@@ -14,6 +14,6 @@
  'data': ['security/ir.model.access.csv',
           ],
  'installable': True,
- 'development_status': 'Stable',
+ 'development_status': 'Production/Stable',
  'maintainers': ['guewen'],
  }


### PR DESCRIPTION
Backport of #371 as it happens `@model_create_multi` was already there in 12.0