### PR TITLE
[13.0][FIX] component: Inherit ComponentRegistryCase from odoo.common.TreeCase

### DIFF
--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -2,7 +2,6 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
 import copy
-import unittest
 from contextlib import contextmanager
 
 import odoo
@@ -105,7 +104,7 @@ class SavepointComponentCase(common.SavepointCase, ComponentMixin):
 
 
 class ComponentRegistryCase(
-    unittest.TestCase, common.MetaCase("DummyCase", (object,), {})
+    common.TreeCase, common.MetaCase("DummyCase", (object,), {})
 ):
     """ This test case can be used as a base for writings tests on components
 

--- a/component_event/tests/test_event.py
+++ b/component_event/tests/test_event.py
@@ -5,7 +5,7 @@ import unittest
 
 import mock
 
-from odoo.tests.common import tagged
+from odoo.tests.common import tagged, TreeCase
 
 from odoo.addons.component.core import Component
 from odoo.addons.component.tests.common import (
@@ -17,7 +17,7 @@ from odoo.addons.component_event.core import EventWorkContext
 
 
 @tagged("standard", "at_install")
-class TestEventWorkContext(unittest.TestCase):
+class TestEventWorkContext(TreeCase):
     """ Test Events Components """
 
     def setUp(self):


### PR DESCRIPTION
This PR fix missing methods
cc @Tecnativa 
ping @carlosdauden @joao-p-marques 

Before this PR:

```
2021-06-23 14:19:58,419 65 [1;32m[1;49mINFO[0m test odoo.modules.loading: Module component_event: loading demo 
2021-06-23 14:19:58,439 65 [1;32m[1;49mINFO[0m test odoo.modules.module: odoo.addons.component_event.tests.test_event running tests. 
2021-06-23 14:19:58,440 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_collect_several ... 
2021-06-23 14:19:58,496 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_event ... 
2021-06-23 14:19:58,552 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_event_cache ... 
2021-06-23 14:19:58,608 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_event_cache_collection ... 
2021-06-23 14:19:58,664 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_event_cache_model_name ... 
2021-06-23 14:19:58,720 65 [1;32m[1;49mINFO[0m test odoo.addons.component_event.tests.test_event: Starting TestEvent.test_skip_if ... 
2021-06-23 14:19:58,779 65 [1;33m[1;49mWARNING[0m test odoo.modules.loading: Transient module states were reset 
2021-06-23 14:19:58,784 65 [1;31m[1;49mERROR[0m test odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 423, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 315, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 257, in load_module_graph
    report.record_result(odoo.modules.module.run_unit_tests(module_name))
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 640, in run_unit_tests
    result = OdooTestRunner().run(suite)
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 609, in run
    test(result)
  File "/usr/local/lib/python3.6/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.6/unittest/suite.py", line 112, in run
    self._tearDownPreviousClass(test, result)
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 251, in _tearDownPreviousClass
    previousClass.doClassCleanups()
AttributeError: type object 'TestEvent' has no attribute 'doClassCleanups'
2021-06-23 14:19:58,785 65 [1;37m[1;41mCRITICAL[0m test odoo.service.server: Failed to initialize database `test`. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1192, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 423, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 315, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 257, in load_module_graph
    report.record_result(odoo.modules.module.run_unit_tests(module_name))
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 640, in run_unit_tests
    result = OdooTestRunner().run(suite)
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 609, in run
    test(result)
  File "/usr/local/lib/python3.6/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.6/unittest/suite.py", line 112, in run
    self._tearDownPreviousClass(test, result)
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 251, in _tearDownPreviousClass
    previousClass.doClassCleanups()
AttributeError: type object 'TestEvent' has no attribute 'doClassCleanups'
```

After this PR, the test has been fixed

I don't know if this is the best way to fix the test...