### PR TITLE
[14.0][REF] Clean-up Python 2 idioms

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -60,7 +60,7 @@ class ComponentDatabases(dict):
     """ Holds a registry of components for each database """
 
 
-class ComponentRegistry(object):
+class ComponentRegistry:
     """Store all the components and allow to find them using criteria
 
     The key is the ``_name`` of the components.
@@ -169,7 +169,7 @@ class ComponentRegistry(object):
 _component_databases = ComponentDatabases()
 
 
-class WorkContext(object):
+class WorkContext:
     """Transport the context required to work with components
 
     It is propagated through all the components, so any
@@ -518,7 +518,7 @@ class MetaComponent(type):
         return cls._apply_on
 
 
-class AbstractComponent(object, metaclass=MetaComponent):
+class AbstractComponent(metaclass=MetaComponent):
     """Main Component Model
 
     All components have a Python inheritance either on

--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -25,7 +25,7 @@ def new_rollbacked_env():
         cr.close()
 
 
-class ComponentMixin(object):
+class ComponentMixin:
     @classmethod
     def setUpComponent(cls):
         with new_rollbacked_env() as env:
@@ -105,9 +105,7 @@ class SavepointComponentCase(common.SavepointCase, ComponentMixin):
         ComponentMixin.setUp(self)
 
 
-class ComponentRegistryCase(
-    unittest.TestCase, common.MetaCase("DummyCase", (object,), {})
-):
+class ComponentRegistryCase(unittest.TestCase, common.MetaCase("DummyCase", (), {})):
     """This test case can be used as a base for writings tests on components
 
     This test case is meant to test components in a special component registry,

--- a/component_event/components/event.py
+++ b/component_event/components/event.py
@@ -164,7 +164,7 @@ def skip_if(cond):
     return skip_if_decorator
 
 
-class CollectedEvents(object):
+class CollectedEvents:
     """Event methods ready to be notified
 
     This is a rather internal class. An instance of this class

--- a/connector/components/mapper.py
+++ b/connector/components/mapper.py
@@ -936,7 +936,7 @@ class ExportMapper(AbstractComponent):
         return value
 
 
-class MapRecord(object):
+class MapRecord:
     """A record prepared to be converted using a :py:class:`Mapper`.
 
     MapRecord instances are prepared by :py:meth:`Mapper.map_record`.

--- a/connector/doc/guides/bootstrap_connector.rst
+++ b/connector/doc/guides/bootstrap_connector.rst
@@ -34,9 +34,8 @@ First, we need to create the Odoo addons itself, editing the
 
 
 .. code-block:: python
-   :emphasize-lines: 4,5
+   :emphasize-lines: 3,4
 
-    # -*- coding: utf-8 -*-
     {'name': 'Coffee Connector',
      'version': '1.0.0',
      'category': 'Connector',
@@ -52,7 +51,7 @@ First, we need to create the Odoo addons itself, editing the
 
     Features:
 
-    * Poor a coffee when Odoo is busy for too long
+    * Pour a coffee when Odoo is busy for too long
     """,
      'data': [],
      'installable': True,


### PR DESCRIPTION
These are deprecated in Python 3:
 - `coding: utf-8` for UTF-8 source code
 - explicit `(object)` inheritance