### PR TITLE
[FIX] Sometimes hashed is negative and not lock

### DIFF
--- a/connector/database.py
+++ b/connector/database.py
@@ -72,7 +72,8 @@ def pg_try_advisory_lock(env, lock):
     # pg_lock accepts an int8 so we build an hash composed with
     # contextual information and we throw away some bits
     int_lock = struct.unpack("q", hasher.digest()[:8])
-
+    if int_lock[0] < 0:
+        int_lock[0] = int_lock[0] * -1
     env.cr.execute("SELECT pg_try_advisory_xact_lock(%s);", (int_lock,))
     acquired = env.cr.fetchone()[0]
     return acquired


### PR DESCRIPTION

Sometimes when locking a resource, the result of the hash would return a negative integer. Postgres always returns False when calling SELECT pg_try_advisory_xact_lock(%s)

Below I put my pip freeze and my postgres version

```
aiohttp==3.8.1
aiosignal==1.2.0
apispec==5.1.1
appdirs==1.4.3
argcomplete==2.0.0
asn1crypto==1.5.1
async-timeout==4.0.2
attrs==19.3.0
Automat==0.8.0
Babel==2.6.0
base58==2.1.1
bcrypt==3.2.0
beautifulsoup4==4.10.0
bitarray==1.2.2
blinker==1.4
bs4==0.0.1
cached-property==1.5.2
cachetools==5.0.0
Cerberus==1.3.4
certifi==2019.11.28
cffi==1.15.0
cfgv==3.3.1
chardet==3.0.4
charset-normalizer==2.0.12
Click==7.0
cloud-init==22.2
colorama==0.4.3
command-not-found==0.3
configobj==5.0.6
constantly==15.1.0
cryptography==38.0.3
cssselect==1.1.0
cytoolz==0.11.2
dataclasses==0.6
dbus-python==1.2.16
decorator==4.4.2
defusedxml==0.7.1
distlib==0.3.0
distro==1.4.0
distro-info===0.23ubuntu1
docutils==0.16
ebaysdk==2.1.5
ec2-hibinit-agent==1.0.0
entrypoints==0.3
eth-abi==2.1.1
eth-account==0.5.7
eth-hash==0.3.2
eth-keyfile==0.5.1
eth-keys==0.3.4
eth-rlp==0.3.0
eth-typing==2.3.0
eth-utils==1.10.0
filelock==3.0.12
freezegun==0.3.15
frozenlist==1.3.0
future==0.18.2
gevent==20.9.0
git-aggregator==2.1.0
greenlet==0.4.17
hexbytes==0.2.2
hibagent==1.0.1
html2text==2020.1.16
httplib2==0.14.0
hyperlink==19.0.0
identify==2.4.10
idna==2.8
importlib-metadata==1.5.0
incremental==16.10.1
ipfshttpclient==0.8.0a2
isodate==0.6.1
Jinja2==2.11.2
jsondiff==1.3.1
jsonpatch==1.22
jsonpointer==2.0
jsonschema==3.2.0
kaptan==0.5.12
keyring==18.0.1
language-selector==0.1
launchpadlib==1.10.13
lazr.restfulclient==0.14.2
lazr.uri==1.0.3
libsass==0.18.0
lru-dict==1.1.7
lxml==4.6.1
Mako==1.1.6
MarkupSafe==1.1.0
marshmallow==3.14.1
marshmallow-objects==2.3.0
mock==4.0.3
more-itertools==4.2.0
multiaddr==0.0.9
multidict==6.0.2
netaddr==0.8.0
netifaces==0.10.4
nodeenv==1.6.0
num2words==0.5.6
oauthlib==3.1.0
odoo-test-helper==2.0.1
OdooRPC==0.8.0
OERPLib==0.8.4
OERPLib-py3==0.8.6
ofxparse==0.19
openupgradelib==3.3.5.dev10+g14ffca6
packaging==20.3
paramiko==2.9.2
parse-accept-language==0.1.2
parsimonious==0.8.1
passlib==1.7.2
pdfkit==0.5.0
pexpect==4.6.0
phonenumbers==8.13.0
Pillow==8.1.2
pipx==1.1.0
pluggy==0.13.0
polib==1.1.0
pre-commit==2.17.0
prestapyt-flachica==0.11.5
protobuf==3.19.4
psutil==5.6.6
psycopg2==2.8.6
py==1.8.1
pyasn1==0.4.2
pyasn1-modules==0.2.1
pycountry==22.3.5
pycparser==2.21
pycryptodome==3.14.1
pycups==2.0.1
pydot==1.4.1
PyGObject==3.36.0
PyHamcrest==1.9.0
PyJWT==1.7.1
pymacaroons==0.13.0
PyNaCl==1.3.0
pyOpenSSL==22.1.0
pyparsing==2.4.6
PyPDF2==1.26.0
pyquerystring==1.1
pyrsistent==0.15.5
pyserial==3.4
pysftp==0.2.9
python-apt==2.0.0+ubuntu0.20.4.7
python-dateutil==2.7.3
python-debian===0.1.36ubuntu1
python-ldap==3.2.0
python-slugify==6.1.2
python-stdnum==1.17
pytz==2019.3
pyusb==1.0.2
PyYAML==5.3.1
qrcode==6.1
reportlab==3.5.59
requests==2.22.0
requests-pkcs12==1.14
requests-toolbelt==0.9.1
requests-unixsocket==0.2.0
rlp==2.0.1
SecretStorage==2.3.1
service-identity==18.1.0
simplejson==3.16.0
six==1.14.0
sos==4.3
soupsieve==2.3.1
ssh-import-id==5.10
suds-py3==1.4.5.0
systemd-python==234
text-unidecode==1.3
toml==0.10.0
toolz==0.11.2
tox==3.13.2
Twisted==18.9.0
ubuntu-advantage-tools==27.6
ufw==0.36
unattended-upgrades==0.1
unicodecsv==0.14.1
Unidecode==1.3.2
urllib3==1.25.8
userpath==1.8.0
varint==1.0.2
vcrpy==4.1.1
virtualenv==20.0.17
vobject==0.9.6.1
wadllib==1.3.3
web3==5.28.0
websockets==9.1
Werkzeug==0.16.1
wrapt==1.14.1
xlrd==1.2.0
XlsxWriter==1.1.2
xlwt==1.3.0
xmlsig==0.1.9
xmltodict==0.13.0
yarl==1.7.2
zeep==3.4.0
zipp==1.0.0
zope.event==4.5.0
zope.interface==4.7.1
```
Postgres version

```
PostgreSQL 12.12 (Ubuntu 12.12-0ubuntu0.20.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit
```