### PR TITLE
[14.0][FIX] component_event: handle empty vals on create.

### DIFF
--- a/component_event/models/base.py
+++ b/component_event/models/base.py
@@ -100,6 +100,10 @@ class Base(models.AbstractModel):
     @api.model_create_multi
     def create(self, vals_list):
         records = super(Base, self).create(vals_list)
+        if not vals_list:
+            # No vals_list -> no creation. the upstream method returns an empty
+            # recordset.
+            return records
         for idx, vals in enumerate(vals_list):
             fields = list(vals.keys())
             self._event("on_record_create").notify(records[idx], fields=fields)


### PR DESCRIPTION
Upstream `create` method does support an empty vals list. In such case no error is raised, instead an empty recordset is returned and no record is created.

This is useful when using "prepare vals" hook methods, in which you can return `False` if you don't want to create a record. Any extension to the Base model should respect that.

Forward port of https://github.com/OCA/connector/pull/457.