### PR TITLE
[16.0] component_event: fix test base class

### DIFF
--- a/component_event/tests/test_event.py
+++ b/component_event/tests/test_event.py
@@ -1,10 +1,9 @@
 # Copyright 2017 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 
-import unittest
 from unittest import mock
 
-from odoo.tests.common import tagged
+from odoo.tests.common import BaseCase, tagged
 
 from odoo.addons.component.core import Component
 from odoo.addons.component.tests.common import (
@@ -15,8 +14,12 @@ from odoo.addons.component_event.components.event import skip_if
 from odoo.addons.component_event.core import EventWorkContext
 
 
+# NOTE: there's no reason for these tests to depend on BaseCase
+# but we cannot depend on `unittest.TestCase`
+# because Odoo's test suite runner expects to find some attributes on the test class
+# which come from `MetaCase`
 @tagged("standard", "at_install")
-class TestEventWorkContext(unittest.TestCase):
+class TestEventWorkContext(BaseCase):
     """Test Events Components"""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
There's no reason for these tests to depend on BaseCase but we cannot depend on `unittest.TestCase`
because Odoo's test suite runner expects to find some attributes on the test class which come from `BaseCase`.

```
 Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-14>", line 2, in new
  File "/opt/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 487, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/odoo/modules/loading.py", line 371, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 281, in load_module_graph
    suite = loader.make_suite([module_name], 'at_install')
  File "/opt/odoo/odoo/tests/loader.py", line 55, in make_suite
    return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
  File "/opt/odoo/odoo/tests/loader.py", line 53, in <genexpr>
    if position_tag.check(t) and config_tags.check(t)
  File "/opt/odoo/odoo/tests/tag_selector.py", line 54, in check
    test_module = test.test_module
``