### PR TITLE
[FIX] component: remove XML declarations inside HTML files

### DIFF
--- a/component_event/static/description/index.html
+++ b/component_event/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/test_component/static/description/index.html
+++ b/test_component/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
[XML declarations in HTML module descriptions are deprecated sice Odoo 17](https://github.com/odoo/odoo/blob/9d4f8b2fda5c75438ad30a08b4f7d95eac4f2f23/odoo/addons/base/models/ir_module.py#L184-L191)