### PR TITLE
[18.0][FIX] connector_base_product: remove wrong invisible attribute

### DIFF
--- a/connector_base_product/views/product_view.xml
+++ b/connector_base_product/views/product_view.xml
@@ -11,9 +11,7 @@
         <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <xpath expr="/form/sheet/notebook" position="inside">
-                <!-- change the invisible attribute to 0 when used
-                     in submodules -->
-                <page string="Connectors" name="connector" invisible="True" />
+                <page string="Connectors" name="connector" />
             </xpath>
         </field>
     </record>
@@ -24,9 +22,7 @@
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <xpath expr="/form/sheet/notebook" position="inside">
-                <!-- change the invisible attribute to 0 when used
-                     in submodules -->
-                <page string="Connectors" name="connector" invisible="True" />
+                <page string="Connectors" name="connector" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The migration PR was merged with `invisible=True` on the `Connectors` page.
- [ ] https://github.com/OCA/connector/pull/498

I missed that during migration.
The question is: why has it been invisible since v14?
Is anyone (except our customers) using this module?
It doesn't make any sense.
https://github.com/OCA/connector/blob/14.0/connector_base_product/views/product_view.xml