### PR TITLE
[16.0][FIX] connector: adapt tests to Acme Corporation demo data

### DIFF
--- a/connector/tests/test_mapper.py
+++ b/connector/tests/test_mapper.py
@@ -687,7 +687,7 @@ class TestMapperRecordsets(TransactionComponentRegistryCase):
         )
         mapper = self.comp_registry["my.mapper"](self.work)
         map_record = mapper.map_record(partner)
-        expected = {"parent_name": "Deco Addict"}
+        expected = {"parent_name": "Acme Corporation"}
         self.assertEqual(map_record.values(), expected)
         self.assertEqual(map_record.values(for_create=True), expected)
 


### PR DESCRIPTION
regarding odoo recent FIX: replace "Deco Addict" with "Acme Corporation"

A company that happens to be named "Deco Addict" has complained some of our users thought they had business with them due to test and demo data containing that name.

It will now be named Acme Corporation.