### PR TITLE
8.0 jobrunner: support pgbouncer. named cursor to iterate jobs.

### DIFF
--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -209,7 +209,8 @@ class Database(object):
 
     def __init__(self, db_name):
         self.db_name = db_name
-        self.conn = psycopg2.connect(openerp.sql_db.dsn(db_name)[1])
+        session_pool_suffix = config.get("db_session_pool_mode_suffix", '')
+        self.conn = psycopg2.connect(openerp.sql_db.dsn(db_name + session_pool_suffix)[1])
         self.conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         self.has_connector = self._has_connector()
         if self.has_connector:

--- a/connector/jobrunner/runner.py
+++ b/connector/jobrunner/runner.py
@@ -112,7 +112,7 @@ Caveat
        of running Odoo is obviously not for production purposes.
 """
 
-from contextlib import closing
+from contextlib import closing, contextmanager
 import logging
 import os
 import re
@@ -290,15 +290,16 @@ class Database(object):
             """)
             cr.execute("LISTEN connector")
 
+    @contextmanager
     def select_jobs(self, where, args):
         query = ("SELECT %s, uuid, id as seq, date_created, "
                  "priority, eta, state "
                  "FROM queue_job WHERE %s" %
                  ('channel' if self.has_channel else 'NULL',
                   where))
-        with closing(self.conn.cursor()) as cr:
+        with closing(self.conn.cursor("select_jobs", withhold=True)) as cr:
             cr.execute(query, args)
-            return list(cr.fetchall())
+            yield cr
 
     def set_job_enqueued(self, uuid):
         with closing(self.conn.cursor()) as cr:
@@ -347,8 +348,9 @@ class ConnectorRunner(object):
                 _logger.debug('connector is not installed for db %s', db_name)
             else:
                 self.db_by_name[db_name] = db
-                for job_data in db.select_jobs('state in %s', (NOT_DONE,)):
-                    self.channel_manager.notify(db_name, *job_data)
+                with db.select_jobs('state in %s', (NOT_DONE,)) as cr:
+                    for job_data in cr.fetchall():
+                        self.channel_manager.notify(db_name, *job_data)
                 _logger.info('connector runner ready for db %s', db_name)
 
     def run_jobs(self):
@@ -368,11 +370,12 @@ class ConnectorRunner(object):
                     break
                 notification = db.conn.notifies.pop()
                 uuid = notification.payload
-                job_datas = db.select_jobs('uuid = %s', (uuid,))
-                if job_datas:
-                    self.channel_manager.notify(db.db_name, *job_datas[0])
-                else:
-                    self.channel_manager.remove_job(uuid)
+                with db.select_jobs('uuid = %s', (uuid,)) as cr:
+                    job_datas = cr.fetchone()
+                    if job_datas:
+                        self.channel_manager.notify(db.db_name, *job_datas)
+                    else:
+                        self.channel_manager.remove_job(uuid)
 
     def wait_notification(self):
         for db in self.db_by_name.values():


### PR DESCRIPTION
1. jobrunner: use named cursor to iterate jobs. backport of OCA/queue@ae3e64ee and OCA/queue@f0fc575f with fixed line `for job_data in cr.fetchall():`.
2. jobrunner: support pgbouncer via `db_session_pool_mode_suffix` config.

PGBouncer is typically configured with `pool_mode = transaction` that does not support LISTEN/NOTIFY of postgre. This patch adds support of additional `pool_mode = session` entry, thus allowing connector module to work as it fully relies on LISTEN/NOTIFY.

LISTEN/NOTIFY is used by `bus.bus` (IM), `web_auto_refresh`, `connector` etc.

Example `odoo.conf`:
```
db_name = odoo
db_session_pool_mode_suffix = _bus
```

Example `pgbouncer.ini` with additional entries in `pool_mode=session` (`odoo_bus`, `postgres_bus`):
```
[databases]
odoo = host=xx.xx.xx.xx port=yy dbname=odoo pool_mode=transaction
odoo_bus = host=xx.xx.xx.xx port=yy dbname=odoo pool_mode=session pool_size=5
postgres = host=xx.xx.xx.xx port=yy dbname=postgres pool_size=20
postgres_bus = host=xx.xx.xx.xx port=yy dbname=postgres pool_mode=session pool_size=5

[pgbouncer]
pool_mode = transaction
```
