### PR TITLE
[18.0] component: ease ComponentMixin setup

### DIFF
--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -46,6 +46,9 @@ class ComponentMixin:
 
     # pylint: disable=W8106
     def setUp(self):
+        self.setUpComponentRegistryReady()
+
+    def setUpComponentRegistryReady(self):
         # should be ready only during tests, never during installation
         # of addons
         self._components_registry.ready = True


### PR DESCRIPTION
Split the part to make the registry ready so that depending module can set up the registry properly w/o relying on nested setUpcalls which might be not working properly in case of multiple inheritance.

Side effect of the Odoo tests apocalypse :/