### PR TITLE
Revert "component: allow ctx override at init"

### DIFF
--- a/component/core.py
+++ b/component/core.py
@@ -699,7 +699,6 @@ class AbstractComponent(metaclass=MetaComponent):
     def __init__(self, work_context):
         super().__init__()
         self.work = work_context
-        self.env = work_context.env
 
     @classmethod
     def _component_match(cls, work, usage=None, model_name=None, **kw):
@@ -726,6 +725,11 @@ class AbstractComponent(metaclass=MetaComponent):
     def collection(self):
         """Collection we are working with"""
         return self.work.collection
+
+    @property
+    def env(self):
+        """Current Odoo environment, the one of the collection record"""
+        return self.work.env
 
     @property
     def model(self):

--- a/component/tests/test_component.py
+++ b/component/tests/test_component.py
@@ -37,10 +37,6 @@ class TestComponent(TransactionComponentRegistryCase):
             _usage = "for.test"
             _apply_on = ["res.partner"]
 
-            def __init__(self, work_context):
-                super().__init__(work_context)
-                self.env = self.env(context=dict(self.env.context, foo="bar"))
-
         class Component2(Component):
             _name = "component2"
             _collection = "collection.base"
@@ -55,10 +51,6 @@ class TestComponent(TransactionComponentRegistryCase):
         # our collection, in a less abstract use case, it
         # could be a record of 'magento.backend' for instance
         self.collection_record = self.collection.new()
-        # add ctx key to ensure it's preserved later
-        self.collection_record = self.collection_record.with_context(
-            from_collection=True
-        )
 
         @contextmanager
         def get_base():
@@ -86,8 +78,7 @@ class TestComponent(TransactionComponentRegistryCase):
             # but this is not what we test here, we test the attributes:
             self.assertEqual(self.collection_record, comp.collection)
             self.assertEqual(base.work, comp.work)
-            self.assertEqual(comp.env.context["from_collection"], True)
-            self.assertEqual(comp.env.context["foo"], "bar")
+            self.assertEqual(self.env, comp.env)
             self.assertEqual(self.env["res.partner"], comp.model)
 
     def test_component_get_by_name_same_model(self):


### PR DESCRIPTION
This reverts commit ee7bd1a16ab8aa3af9144d042080445ad8b992e4 as it's breaking tests on depending modules.

From #504 

Unfortunately this works only w/ py > 3.10.

Explanation on #529 