### PR TITLE
[18.0][IMP] component: improve test setup

### DIFF
--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -72,17 +72,6 @@ class TransactionComponentCase(common.TransactionCase, ComponentMixin):
         super().setUpClass()
         cls.setUpComponent()
 
-    # pylint: disable=W8106
-    def setUp(self):
-        # resolve an inheritance issue (common.TransactionCase does not call
-        # super)
-        common.TransactionCase.setUp(self)
-        ComponentMixin.setUp(self)
-        # There's no env on setUpClass of TransactionCase, must do it here.
-        self.env.context = dict(
-            self.env.context, components_registry=self._components_registry
-        )
-
 
 class ComponentRegistryCase:
     """This test case can be used as a base for writings tests on components


### PR DESCRIPTION
Class ``TransactionComponentCase.setUp()`` was not calling ``super()`` because of an inheritance issue: ``odoo.tests.common.TransactionCase.setUp()`` was not calling ``super()`` either.

Since the issue has been solved, the test setup can be improved, allowing subclasses that inherit from ``TransactionComponentCase`` to correctly resolve the chain of ``super().setUp()`` calls.