### PR TITLE
[18.0][FIX] component: fix test setup

### DIFF
--- a/component/tests/common.py
+++ b/component/tests/common.py
@@ -44,10 +44,6 @@ class ComponentMixin:
                     cls.env.context, components_registry=cls._components_registry
                 )
 
-    # pylint: disable=W8106
-    def setUp(self):
-        self.setUpComponentRegistryReady()
-
     def setUpComponentRegistryReady(self):
         # should be ready only during tests, never during installation
         # of addons
@@ -71,6 +67,10 @@ class TransactionComponentCase(common.TransactionCase, ComponentMixin):
     def setUpClass(cls):
         super().setUpClass()
         cls.setUpComponent()
+
+    def setUp(self):
+        super().setUp()
+        self.setUpComponentRegistryReady()
 
 
 class ComponentRegistryCase:


### PR DESCRIPTION
Commit 6344297 improved test setup, but introduced a bug: the components registry was never flagged as 'ready' anymore. This commit fixes such bug.