### PR TITLE
[18.0][FIX] connector: ignore empty external IDs in the binder

### DIFF
--- a/connector/components/binder.py
+++ b/connector/components/binder.py
@@ -76,7 +76,9 @@ class Binder(AbstractComponent):
             bindings.ensure_one()
         if unwrap:
             bindings = bindings[self._odoo_field]
-        return bindings.with_context(**context)
+        # Restore the context: dropping the ``active_test`` key
+        # pylint: disable=context-overridden
+        return bindings.with_context(context)
 
     def to_external(self, binding, wrap=False):
         """Give the external ID for an Odoo binding ID

--- a/connector/components/binder.py
+++ b/connector/components/binder.py
@@ -37,6 +37,19 @@ class Binder(AbstractComponent):
     _odoo_field = "odoo_id"  # override in sub-classes
     _sync_date_field = "sync_date"  # override in sub-classes
 
+    def _is_empty_id(self, value):
+        """Return ``True`` if ``value`` is an empty identifier
+
+        ``None``, ``False``, ``True`` and ``""`` mean "no ID", but ``0`` is a
+        valid one.
+
+        :param value: identifier to check, e.g. an external ID
+        :return: True if the identifier is empty
+        :rtype: bool
+        """
+        # ``False == 0`` and ``True == 1`` both evaluate to ``True``
+        return value is None or isinstance(value, bool) or value == ""
+
     def to_internal(self, external_id, unwrap=False):
         """Give the Odoo recordset for an external ID
 
@@ -49,21 +62,21 @@ class Binder(AbstractComponent):
         :rtype: recordset
         """
         context = self.env.context
-        bindings = self.model.with_context(active_test=False).search(
-            [
-                (self._external_field, "=", external_id),
-                (self._backend_field, "=", self.backend_record.id),
-            ]
-        )
-        if not bindings:
-            if unwrap:
-                return self.model.browse()[self._odoo_field]
-            return self.model.browse()
-        bindings.ensure_one()
+        bindings = self.model
+        # Searching an empty external ID would match every binding of the
+        # backend which is not bound yet.
+        if not self._is_empty_id(external_id):
+            bindings = self.model.with_context(active_test=False).search(
+                [
+                    (self._external_field, "=", external_id),
+                    (self._backend_field, "=", self.backend_record.id),
+                ]
+            )
+        if bindings:
+            bindings.ensure_one()
         if unwrap:
             bindings = bindings[self._odoo_field]
-        bindings = bindings.with_context(**context)
-        return bindings
+        return bindings.with_context(**context)
 
     def to_external(self, binding, wrap=False):
         """Give the external ID for an Odoo binding ID
@@ -98,10 +111,10 @@ class Binder(AbstractComponent):
         :param binding: Odoo record to bind
         :type binding: int
         """
-        # Prevent False, None, or "", but not 0
-        assert (external_id or external_id == 0) and binding, (
-            "external_id or binding missing, " f"got: {external_id}, {binding}"
-        )
+        # Prevent None, False, True or "", but not 0
+        assert (
+            not self._is_empty_id(external_id) and binding
+        ), f"external_id or binding missing, got: {external_id}, {binding}"
         # avoid to trigger the export when we modify the `external_id`
         now_fmt = fields.Datetime.now()
         if isinstance(binding, models.BaseModel):

--- a/connector/readme/CONTRIBUTORS.md
+++ b/connector/readme/CONTRIBUTORS.md
@@ -25,3 +25,4 @@
 - Eric Antones at NuoBiT Solutions S.L.
 - Asier Neira at Factor Libre S.L.
 - Nguyen Minh Chien at Trobz.
+- Mohamed Triki at QoQa Services SA

--- a/test_connector/models/models.py
+++ b/test_connector/models/models.py
@@ -27,7 +27,7 @@ class ConnectorTestBinding(models.Model):
         required=True,
         ondelete="restrict",
     )
-    external_id = fields.Integer(string="ID on External")
+    external_id = fields.Char(string="ID on External")
     odoo_id = fields.Many2one(
         comodel_name="connector.test.record",
         string="Test Record",

--- a/test_connector/tests/test_default_binder.py
+++ b/test_connector/tests/test_default_binder.py
@@ -78,6 +78,28 @@ class TestDefaultBinder(TransactionComponentCase):
                     self.assertFalse(binder.to_internal(external_id))
                     self.assertFalse(binder.to_internal(external_id, unwrap=True))
 
+    def test_to_internal_returned_context(self):
+        """The returned recordset keeps the environment context"""
+        # The search is done with ``active_test=False``: this should not leak in
+        # the returned recordset, whether a binding is found or not.
+        backend = self.backend_record.with_context(test_key="42")
+        with backend.work_on("connector.test.binding") as work:
+            binder = work.component(usage="binder")
+            expected_context = binder.env.context
+            self.assertEqual(expected_context.get("test_key"), "42")
+
+            test_record = self.env["connector.test.record"].create({})
+            test_binding = self.env["connector.test.binding"].create(
+                {"backend_id": self.backend_record.id, "odoo_id": test_record.id}
+            )
+            binder.bind("99", test_binding)
+
+            # Bound external ID, unbound one and empty one
+            for external_id in ("99", "1234", False):
+                for unwrap in (False, True):
+                    record = binder.to_internal(external_id, unwrap=unwrap)
+                    self.assertEqual(record.env.context, expected_context)
+
     def test_bind_empty_external_id(self):
         """Binding an empty external ID raise an error"""
         with self.backend_record.work_on("connector.test.binding") as work:

--- a/test_connector/tests/test_default_binder.py
+++ b/test_connector/tests/test_default_binder.py
@@ -26,19 +26,67 @@ class TestDefaultBinder(TransactionComponentCase):
             )
 
             # bind the test binding to external id = 99
-            self.binder.bind(99, test_binding)
+            self.binder.bind("99", test_binding)
             # find the odoo binding bound to external record 99
-            binding = self.binder.to_internal(99)
+            binding = self.binder.to_internal("99")
             self.assertEqual(binding, test_binding)
             # find the odoo record bound to external record 99
-            record = self.binder.to_internal(99, unwrap=True)
+            record = self.binder.to_internal("99", unwrap=True)
             self.assertEqual(record, test_record)
             # find the external record bound to odoo binding
             external_id = self.binder.to_external(test_binding)
-            self.assertEqual(external_id, 99)
+            self.assertEqual(external_id, "99")
             # find the external record bound to odoo record
             external_id = self.binder.to_external(test_record, wrap=True)
-            self.assertEqual(external_id, 99)
+            self.assertEqual(external_id, "99")
             self.assertEqual(self.binder.unwrap_model(), "connector.test.record")
             # unwrapping the binding should give the same binding
             self.assertEqual(self.binder.unwrap_binding(test_binding), test_record)
+
+    def test_to_internal_external_id_zero(self):
+        """``0`` is a valid external ID"""
+        with self.backend_record.work_on("no.inherits.binding") as work:
+            binder = work.component(usage="binder")
+            self.env["no.inherits.binding"].create(
+                {"backend_id": self.backend_record.id, "external_id": 5}
+            )
+
+            test_binding = self.env["no.inherits.binding"].create(
+                {"backend_id": self.backend_record.id}
+            )
+            self.assertEqual(0, test_binding.external_id)
+            self.assertEqual(binder.to_internal(0), test_binding)
+
+            binder.bind(0, test_binding)
+            self.assertEqual(binder.to_internal(0), test_binding)
+
+    def test_to_internal_empty_external_id(self):
+        """An empty external ID is not bound to anything"""
+        with self.backend_record.work_on("connector.test.binding") as work:
+            binder = work.component(usage="binder")
+            # Several bindings of the backend have no external ID yet: their
+            # column is NULL (False), which is what an empty external ID matches
+            for _i in range(3):
+                test_record = self.env["connector.test.record"].create({})
+                test_binding = self.env["connector.test.binding"].create(
+                    {"backend_id": self.backend_record.id, "odoo_id": test_record.id}
+                )
+                self.assertFalse(test_binding.external_id)
+
+            for external_id in (None, False, True, ""):
+                with self.subTest(external_id=external_id):
+                    self.assertFalse(binder.to_internal(external_id))
+                    self.assertFalse(binder.to_internal(external_id, unwrap=True))
+
+    def test_bind_empty_external_id(self):
+        """Binding an empty external ID raise an error"""
+        with self.backend_record.work_on("connector.test.binding") as work:
+            binder = work.component(usage="binder")
+            test_record = self.env["connector.test.record"].create({})
+            test_binding = self.env["connector.test.binding"].create(
+                {"backend_id": self.backend_record.id, "odoo_id": test_record.id}
+            )
+            for external_id in (None, False, True, ""):
+                with self.subTest(external_id=external_id):
+                    with self.assertRaises(AssertionError):
+                        binder.bind(external_id, test_binding)

--- a/test_connector/tests/test_related_action_binding.py
+++ b/test_connector/tests/test_related_action_binding.py
@@ -19,7 +19,7 @@ class TestRelatedActionBinding(TransactionComponentCase):
     def test_unwrap_binding(self):
         """Call the unwrap binding related action"""
         binding = self.env["connector.test.binding"].create(
-            {"backend_id": self.backend_record.id, "external_id": 99}
+            {"backend_id": self.backend_record.id, "external_id": "99"}
         )
 
         job = binding.with_delay().job_related_action_unwrap()
@@ -57,7 +57,7 @@ class TestRelatedActionBinding(TransactionComponentCase):
     def test_unwrap_binding_not_exists(self):
         """Call the related action on the model on non-existing record"""
         binding = self.env["connector.test.binding"].create(
-            {"backend_id": self.backend_record.id, "external_id": 99}
+            {"backend_id": self.backend_record.id, "external_id": "99"}
         )
 
         job = binding.with_delay().job_related_action_unwrap()


### PR DESCRIPTION
Two fixs:

- ``Binder.to_internal(False)`` no longer searches every binding of the backend not bound yet
- ``Binder.to_internal()`` correctly restores the environment context, without the ``active_test=False`` key
